### PR TITLE
chore(ci): refresh drift snapshots for create-vite and tanstack-cli

### DIFF
--- a/.github/snapshots/create-vite.txt
+++ b/.github/snapshots/create-vite.txt
@@ -7,6 +7,7 @@ When running in TTY, the CLI will start in interactive mode.
 Options:
   -t, --template NAME                   use a specific template
   -i, --immediate                       install dependencies and start dev
+  --overwrite                           remove existing files if target directory is not empty
   --interactive / --no-interactive      force interactive / non-interactive mode
 
 Available templates:

--- a/.github/snapshots/tanstack-cli.txt
+++ b/.github/snapshots/tanstack-cli.txt
@@ -6,7 +6,7 @@ Arguments:
   project-name                                     name of the project
 
 Options:
-  --framework <type>                               project framework (React, Solid) (default: "React")
+  --framework <type>                               project framework (React, Solid)
   --starter [url-or-id]                            DEPRECATED: use --template. Initializes from a template URL or built-in id (default: false)
   --template-id <id>                               initialize using a built-in template id
   --template [url-or-id]                           initialize this project from a template URL or built-in template id


### PR DESCRIPTION
## Summary
- Refresh `.github/snapshots/create-vite.txt` to include the new `--overwrite` flag (already mapped in `packages/core/src/registry/scaffolders/web.ts:132` as `{ unified: 'overwrite', native: '--overwrite' }`, so no scaffolder change required).
- Refresh `.github/snapshots/tanstack-cli.txt` to drop `(default: "React")` from the `--framework` line — purely cosmetic upstream change, no behavioral impact on our scaffolder.

Verified locally by running `npx create-vite@latest --help` and `npx @tanstack/cli create --help`, normalizing both via `.github/scripts/normalize-help.mjs`, and diffing against the updated snapshots — both produce zero drift.

Closes #35
Closes #36

## Test plan
- [x] `diff` of normalized current vs. updated snapshot is empty for both tools
- [x] Pre-commit hook (full vitest run) passed
- [ ] Next scheduled `Upstream Flag Drift Detection` workflow run reports no drift for these two tools