### PR TITLE
feat(cli): add --dry-run and --explain to scaffold

### DIFF
--- a/.changeset/dry-run-explain.md
+++ b/.changeset/dry-run-explain.md
@@ -1,0 +1,7 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/core": minor
+"@tinkerise/shared": minor
+---
+
+Add `--dry-run` and `--explain` to preview the exact upstream scaffolder command (plus flag mappings and prerequisites) without executing. Supports `--json` for machine-readable plans.

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -17,7 +17,7 @@ import type { PresetData, ScaffolderCategory, TinkeriseUserConfig } from '@tinke
 import type { Command } from 'commander'
 import { join } from 'node:path'
 import * as p from '@clack/prompts'
-import { ConfigValidationError, detectPackageManager, executeScaffolder, findClosestMatch, InvalidCategoryError, isCI, loadPreset, resolveConfig, tinkeriseSummaryCard } from '@tinkerise/core'
+import { ConfigValidationError, detectPackageManager, executeScaffolder, findClosestMatch, InteractivePromptBlockedError, InvalidCategoryError, isCI, loadPreset, resolveConfig, tinkeriseSummaryCard } from '@tinkerise/core'
 import pc from 'picocolors'
 import { setSessionContext, writeSessionFile } from '../context/session.js'
 import { runPromptFlow } from '../prompts/flow.js'
@@ -25,11 +25,13 @@ import { promptPackageManager } from '../prompts/pm-select.js'
 import { promptProjectName, validateProjectName } from '../prompts/project-name.js'
 import { resolveViteTemplate, selectT3Components, selectViteTemplate } from '../prompts/variant-select.js'
 import { showBanner } from '../utils/banner.js'
+import { renderScaffoldPlan } from '../utils/dry-run.js'
 import {
   buildPreselectedOptions,
   ensureNonInteractive,
   mergePromptAndFlags,
 } from '../utils/interactive.js'
+import { isJsonMode } from '../utils/output-mode.js'
 
 /** Valid scaffolder categories */
 const VALID_CATEGORIES: ScaffolderCategory[] = ['web', 'backend', 'mobile']
@@ -66,6 +68,10 @@ export interface ScaffoldOptions {
   preset?: string
   /** Show detailed output (config override messages) */
   verbose?: boolean
+  /** Show the resolved command/plan without executing */
+  dryRun?: boolean
+  /** Explain flag mappings + prerequisites (implies dry-run) */
+  explain?: boolean
 }
 
 /**
@@ -232,8 +238,13 @@ async function executePipeline(
   config?: Partial<TinkeriseUserConfig>,
 ): Promise<void> {
   const userFlags = buildUserFlags(options, cmd, cliOptions, pm, config)
+  const dryRun = Boolean(cliOptions.dryRun || cliOptions.explain)
 
-  // Framework-specific variant handling
+  // --json cannot prompt: a vite/t3 dry-run needing a variant prompt would corrupt output (D-14)
+  if (dryRun && isJsonMode() && (framework === 't3' || (framework === 'vite' && !cliOptions.template))) {
+    throw new InteractivePromptBlockedError('scaffold')
+  }
+
   let extraArgs: string[] = []
 
   if (framework === 'vite') {
@@ -266,19 +277,24 @@ async function executePipeline(
     }
   }
 
-  await executeScaffolder({
+  const plan = await executeScaffolder({
     scaffolderName: framework,
     projectName: name,
     userFlags,
     extraArgs,
+    dryRun,
   })
+
+  if (dryRun) {
+    renderScaffoldPlan(plan, { explain: Boolean(cliOptions.explain), json: isJsonMode() })
+    return
+  }
 
   // Persist session context for cross-process reuse (tinkerise add)
   const absProjectPath = join(process.cwd(), name)
   setSessionContext({ framework, packageManager: pm, projectDir: absProjectPath })
   await writeSessionFile(absProjectPath, { framework, packageManager: pm })
 
-  // Enhanced summary card instead of simple one-liner
   const activeFlags = Object.entries(userFlags)
     .filter(([, v]) => v === true)
     .map(([k]) => k)

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -36,6 +36,16 @@ import { isJsonMode } from '../utils/output-mode.js'
 /** Valid scaffolder categories */
 const VALID_CATEGORIES: ScaffolderCategory[] = ['web', 'backend', 'mobile']
 
+function isDryRun(options: ScaffoldOptions): boolean {
+  return Boolean(options.dryRun || options.explain)
+}
+
+// --json output is non-interactive: any prompt would corrupt the envelope (D-14).
+function assertJsonNonInteractive(dryRun: boolean): void {
+  if (dryRun && isJsonMode())
+    throw new InteractivePromptBlockedError('scaffold')
+}
+
 export interface ScaffoldOptions {
   typescript?: boolean
   tailwind?: boolean
@@ -87,10 +97,12 @@ async function resolvePackageManager(
   flagValue?: string,
   config?: Partial<TinkeriseUserConfig>,
   verbose?: boolean,
+  dryRun = false,
 ): Promise<PackageManager> {
   const pmResult = await detectPackageManager(cwd, flagValue)
 
   if (pmResult.source === 'binary-missing') {
+    assertJsonNonInteractive(dryRun)
     // Detected PM binary is not installed — warn and prompt
     p.log.warn(
       pc.yellow(`${pmResult.pm} was detected but is not installed. Choose a package manager:`),
@@ -105,6 +117,7 @@ async function resolvePackageManager(
   }
 
   if (pmResult.source === 'default') {
+    assertJsonNonInteractive(dryRun)
     // No lockfile or packageManager field found — prompt user to choose
     return promptPackageManager()
   }
@@ -238,12 +251,11 @@ async function executePipeline(
   config?: Partial<TinkeriseUserConfig>,
 ): Promise<void> {
   const userFlags = buildUserFlags(options, cmd, cliOptions, pm, config)
-  const dryRun = Boolean(cliOptions.dryRun || cliOptions.explain)
+  const dryRun = isDryRun(cliOptions)
 
-  // --json cannot prompt: a vite/t3 dry-run needing a variant prompt would corrupt output (D-14)
-  if (dryRun && isJsonMode() && (framework === 't3' || (framework === 'vite' && !cliOptions.template))) {
-    throw new InteractivePromptBlockedError('scaffold')
-  }
+  // vite/t3 prompt for a variant; in --json dry-run that would corrupt output (D-14)
+  if (framework === 't3' || (framework === 'vite' && !cliOptions.template))
+    assertJsonNonInteractive(dryRun)
 
   let extraArgs: string[] = []
 
@@ -318,6 +330,7 @@ export async function runInteractiveFlow(
     // if somehow all args were provided (shouldn't happen in this code path)
   }
 
+  assertJsonNonInteractive(isDryRun(options))
   showBanner()
 
   const { config, preset } = await resolveConfigAndPreset(options)
@@ -348,7 +361,7 @@ export async function runInteractiveFlow(
     preselectedOptions: preselected,
     filterCategory,
   })
-  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose)
+  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose, isDryRun(options))
 
   await executePipeline(answers.framework, answers.name, answers.options, cmd, options, pm, config)
 }
@@ -375,6 +388,7 @@ export async function runCategoryFlow(
     ensureNonInteractive(cmd, category)
   }
 
+  assertJsonNonInteractive(isDryRun(options))
   showBanner()
 
   const { config, preset } = await resolveConfigAndPreset(options)
@@ -393,7 +407,7 @@ export async function runCategoryFlow(
     framework: presetFramework,
     preselectedOptions: preselected,
   })
-  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose)
+  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose, isDryRun(options))
 
   await executePipeline(answers.framework, answers.name, answers.options, cmd, options, pm, config)
 }
@@ -419,12 +433,14 @@ export async function runDirectExecution(
 
   const { config, preset } = await resolveConfigAndPreset(options)
 
+  if (!name)
+    assertJsonNonInteractive(isDryRun(options))
   const projectName = name ?? await promptProjectName(framework)
   const projectNameError = validateProjectName(projectName)
   if (projectNameError) {
     throw new ConfigValidationError('projectName', projectName, 'lowercase letters, numbers, hyphens, dots, underscores; max 64 chars')
   }
-  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose)
+  const pm = await resolvePackageManager(process.cwd(), options.packageManager, config, options.verbose, isDryRun(options))
 
   const preselected = mergePresetFlags(preset, buildPreselectedOptions(cmd))
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,7 +86,9 @@ program
   .option('--api', 'Headless API project')
   .option('--preset <name>', 'Apply a saved preset')
   .option('--verbose', 'Show detailed output')
-  .option('--json', 'Emit machine-readable JSON output (list, doctor, preset list/show)')
+  .option('--json', 'Emit machine-readable JSON output (list, doctor, preset list/show, dry-run)')
+  .option('--dry-run', 'Show the command that would run without executing')
+  .option('--explain', 'Like --dry-run, plus flag and prerequisite details (implies --dry-run)')
 
 // Default action with optional positional arguments
 program

--- a/packages/cli/src/utils/__tests__/dry-run.test.ts
+++ b/packages/cli/src/utils/__tests__/dry-run.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderScaffoldPlan } from '../dry-run.js'
+
+/** A ScaffoldPlan as core would produce it (prerequisites carry extra fields the JSON drops). */
+const plan = {
+  scaffolderName: 'next',
+  command: 'npx',
+  args: ['create-next-app@latest', 'my-app', '--typescript'],
+  prerequisites: [{ command: 'node', versionFlag: '--version', versionRange: '>=20.11.0' }],
+  resolvedFlags: [{ unified: 'typescript', native: ['--typescript'] }],
+  versionUsed: null,
+  upstreamVersion: null,
+}
+
+describe('renderScaffoldPlan', () => {
+  it('emits a valid scaffold.plan envelope in JSON mode', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      renderScaffoldPlan(plan as any, { explain: false, json: true })
+
+      expect(writeSpy).toHaveBeenCalledTimes(1)
+      const payload = JSON.parse((writeSpy.mock.calls[0]?.[0] as string).trim())
+      expect(payload.schemaVersion).toBe(1)
+      expect(payload.command).toBe('scaffold.plan')
+      expect(payload.data.command).toBe('npx')
+      expect(payload.data.args).toContain('--typescript')
+      // JSON projection drops versionFlag, keeps command + versionRange.
+      expect(payload.data.prerequisites).toEqual([{ command: 'node', versionRange: '>=20.11.0' }])
+    }
+    finally {
+      writeSpy.mockRestore()
+    }
+  })
+
+  it('prints the command (and with --explain the flag table + prereqs) in human mode', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      renderScaffoldPlan(plan as any, { explain: true, json: false })
+
+      const out = writeSpy.mock.calls.map(c => String(c[0])).join('')
+      expect(out).toContain('npx create-next-app@latest my-app --typescript')
+      expect(out).toContain('typescript')
+      expect(out).toContain('node')
+    }
+    finally {
+      writeSpy.mockRestore()
+    }
+  })
+
+  it('omits the flag table without --explain', () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      renderScaffoldPlan(plan as any, { explain: false, json: false })
+
+      const out = writeSpy.mock.calls.map(c => String(c[0])).join('')
+      expect(out).toContain('npx create-next-app@latest my-app --typescript')
+      expect(out).not.toContain('Prerequisites')
+    }
+    finally {
+      writeSpy.mockRestore()
+    }
+  })
+})

--- a/packages/cli/src/utils/dry-run.ts
+++ b/packages/cli/src/utils/dry-run.ts
@@ -1,0 +1,55 @@
+import type { ScaffoldPlan } from '@tinkerise/core'
+import { ScaffoldPlanEnvelopeV1Schema } from '@tinkerise/shared'
+import pc from 'picocolors'
+import { emitJson } from './output-mode.js'
+
+export interface RenderOptions {
+  explain: boolean
+  json: boolean
+}
+
+export function renderScaffoldPlan(plan: ScaffoldPlan, opts: RenderOptions): void {
+  if (opts.json) {
+    const envelope = {
+      schemaVersion: 1,
+      command: 'scaffold.plan' as const,
+      data: {
+        scaffolderName: plan.scaffolderName,
+        command: plan.command,
+        args: plan.args,
+        resolvedFlags: plan.resolvedFlags,
+        versionUsed: plan.versionUsed,
+        upstreamVersion: plan.upstreamVersion,
+        prerequisites: plan.prerequisites.map(p => ({
+          command: p.command,
+          versionRange: p.versionRange ?? null,
+        })),
+      },
+    }
+    // parse() before emit guarantees a valid envelope (D-05)
+    emitJson(ScaffoldPlanEnvelopeV1Schema.parse(envelope))
+    return
+  }
+
+  const full = `${plan.command} ${plan.args.join(' ')}`
+  process.stdout.write(`\n${pc.bold('Dry run')} ${pc.dim('— no changes made')}\n\n`)
+  process.stdout.write(`  ${pc.dim('Command:')}\n    ${pc.cyan(full)}\n`)
+
+  if (opts.explain) {
+    if (plan.resolvedFlags.length > 0) {
+      process.stdout.write(`\n  ${pc.dim('Flags:')}\n`)
+      for (const f of plan.resolvedFlags) {
+        process.stdout.write(`    ${f.unified}  ${pc.dim('→')}  ${f.native.join(' ')}\n`)
+      }
+    }
+    if (plan.prerequisites.length > 0) {
+      process.stdout.write(`\n  ${pc.dim('Prerequisites:')}\n`)
+      for (const p of plan.prerequisites) {
+        const range = p.versionRange ? ` (${p.versionRange})` : ''
+        process.stdout.write(`    ${p.command}${range}\n`)
+      }
+    }
+  }
+
+  process.stdout.write(`\n${pc.dim('Run without --dry-run to execute.')}\n`)
+}

--- a/packages/cli/tests/commands/scaffold.test.ts
+++ b/packages/cli/tests/commands/scaffold.test.ts
@@ -16,6 +16,7 @@ import {
   runDirectExecution,
   runInteractiveFlow,
 } from '../../src/commands/scaffold.js'
+import { __resetJsonModeForTests, detectJsonMode } from '../../src/utils/output-mode.js'
 
 // vi.hoisted for mock fns used in vi.mock factories
 const {
@@ -464,5 +465,33 @@ describe('defaultCategory config wiring', () => {
       expect.objectContaining({ filterCategory: undefined }),
     )
     expect(mockLogWarn).not.toHaveBeenCalled()
+  })
+})
+
+describe('--json dry-run non-interactivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockValidateProjectName.mockReturnValue(undefined)
+    mockIsCI.value = false
+    mockResolveConfig.mockResolvedValue({})
+    mockLoadPreset.mockResolvedValue(null)
+    mockBuildPreselectedOptions.mockReturnValue([])
+    mockMergePromptAndFlags.mockReturnValue({})
+    detectJsonMode(['node', 'tinkerise', '--json'])
+  })
+
+  afterEach(() => {
+    __resetJsonModeForTests()
+    mockIsCI.value = false
+  })
+
+  it('blocks instead of prompting for PM when output would be JSON', async () => {
+    mockDetectPackageManager.mockResolvedValue({ pm: 'npm', source: 'default' })
+    const cmd = createMockCommand()
+
+    await expect(
+      runDirectExecution('web', 'next', 'my-app', cmd, { dryRun: true }),
+    ).rejects.toMatchObject({ code: 'INTERACTIVE_PROMPT_BLOCKED' })
+    expect(mockPromptPackageManager).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/executor/__tests__/execute.test.ts
+++ b/packages/core/src/executor/__tests__/execute.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock the side-effecting collaborators so the test is hermetic:
+// - version probe must not shell out
+// - spawn must be observable (and asserted NOT called in dry-run)
+// - prereq enforcement must not touch the real environment
+vi.mock('../process.js', () => ({
+  spawnScaffolder: vi.fn(async () => ({ exitCode: 0 })),
+}))
+vi.mock('../version.js', () => ({
+  detectUpstreamVersion: vi.fn(async () => null),
+}))
+vi.mock('../../prerequisites/checker.js', () => ({
+  checkPrerequisites: vi.fn(async () => {}),
+}))
+
+const { executeScaffolder } = await import('../index.js')
+const { spawnScaffolder } = await import('../process.js')
+const { checkPrerequisites } = await import('../../prerequisites/checker.js')
+
+describe('executeScaffolder dry run', () => {
+  it('dryRun returns a plan and never spawns or enforces prereqs', async () => {
+    vi.mocked(spawnScaffolder).mockClear()
+    vi.mocked(checkPrerequisites).mockClear()
+
+    const plan = await executeScaffolder({
+      scaffolderName: 'next',
+      projectName: 'my-app',
+      userFlags: { typescript: true },
+      dryRun: true,
+    })
+
+    // Dry-run must be side-effect-free: it must work even when the tool/prereqs
+    // are absent, so neither spawn nor prerequisite enforcement may run.
+    expect(spawnScaffolder).not.toHaveBeenCalled()
+    expect(checkPrerequisites).not.toHaveBeenCalled()
+    expect(plan.scaffolderName).toBe('next')
+    expect(plan.command).toBe('npx')
+    expect(plan.args).toContain('my-app')
+    expect(plan.resolvedFlags.some(f => f.unified === 'typescript')).toBe(true)
+  })
+
+  it('non-dry run returns the plan and spawns exactly once', async () => {
+    vi.mocked(spawnScaffolder).mockClear()
+
+    const plan = await executeScaffolder({
+      scaffolderName: 'next',
+      projectName: 'my-app',
+      userFlags: { typescript: true },
+    })
+
+    expect(plan).toBeDefined()
+    expect(plan.scaffolderName).toBe('next')
+    expect(spawnScaffolder).toHaveBeenCalledTimes(1)
+    expect(spawnScaffolder).toHaveBeenCalledWith('npx', plan.args, { cwd: undefined })
+  })
+})

--- a/packages/core/src/executor/index.ts
+++ b/packages/core/src/executor/index.ts
@@ -5,7 +5,8 @@
  *           detect version -> resolve flags -> spawn -> summary
  */
 
-import type { ScaffolderEntry } from '@tinkerise/shared'
+import type { Prerequisite, ScaffolderEntry } from '@tinkerise/shared'
+import type { ResolvedFlagMapping } from '../flags/resolver.js'
 import { ProjectNameSchema } from '@tinkerise/shared'
 import { ConfigValidationError, ScaffolderExitError, ScaffolderNotFoundError } from '../errors/index.js'
 import { resolveFlags } from '../flags/resolver.js'
@@ -31,13 +32,35 @@ export interface ExecuteOptions {
   extraArgs?: string[]
   /** Working directory */
   cwd?: string
+  /** When true, build the plan and return it without enforcing prereqs or spawning */
+  dryRun?: boolean
+}
+
+/**
+ * The fully-resolved scaffolding plan — what `executeScaffolder` would run.
+ * Returned for every invocation; in dry-run mode it is returned without side effects.
+ */
+export interface ScaffoldPlan {
+  scaffolderName: string
+  /** Executable to invoke, e.g. 'npx' */
+  command: string
+  /** Full argument vector passed to the executable */
+  args: string[]
+  /** Prerequisites that would be enforced before a real run */
+  prerequisites: Prerequisite[]
+  /** Per-flag unified→native attribution (for --explain) */
+  resolvedFlags: ResolvedFlagMapping[]
+  /** Version range whose flag mappings were used (null = base flags) */
+  versionUsed: string | null
+  /** Detected upstream tool version (null when undetected/absent) */
+  upstreamVersion: string | null
 }
 
 /**
  * Execute the full detect-map-execute pipeline.
  */
-export async function executeScaffolder(options: ExecuteOptions): Promise<void> {
-  const { scaffolderName, projectName, userFlags, passthroughArgs = [], extraArgs = [], cwd } = options
+export async function executeScaffolder(options: ExecuteOptions): Promise<ScaffoldPlan> {
+  const { scaffolderName, projectName, userFlags, passthroughArgs = [], extraArgs = [], cwd, dryRun = false } = options
   const parsedProjectName = ProjectNameSchema.safeParse(projectName)
   if (!parsedProjectName.success) {
     throw new ConfigValidationError('projectName', projectName, 'lowercase letters, numbers, hyphens, dots, underscores; max 64 chars')
@@ -52,36 +75,52 @@ export async function executeScaffolder(options: ExecuteOptions): Promise<void> 
   // 2. Validate flags apply to this scaffolder
   validateFlagApplicability(entry, userFlags)
 
-  // 3. Check prerequisites
-  tinkeriseLog('Checking prerequisites...')
-  await checkPrerequisites(entry.prerequisites)
-
-  // 4. Detect upstream version (non-fatal)
+  // 3. Detect upstream version (non-fatal — null when the tool is absent)
   const upstreamVersion = await detectUpstreamVersion(entry)
-  if (upstreamVersion) {
-    tinkeriseLog(`Detected ${entry.packageName} v${upstreamVersion}`)
-  }
 
-  // 5. Resolve flags
-  const { args: nativeArgs, versionUsed } = resolveFlags({
+  // 4. Resolve flags (with per-flag breakdown for --explain)
+  const { args: nativeArgs, versionUsed, breakdown } = resolveFlags({
     entry,
     userFlags,
     upstreamVersion,
   })
 
-  if (versionUsed) {
-    tinkeriseLog(`Using flag mappings for version range ${versionUsed}`)
-  }
-
-  // 6. Build final command args based on integration strategy (REG-04)
+  // 5. Build final command args based on integration strategy (REG-04).
   // Merge nativeArgs with extraArgs (framework-specific like Vite template, T3 components)
   const allNativeArgs = [...nativeArgs, ...extraArgs]
   const commandArgs = buildCommandArgs(entry, parsedProjectName.data, allNativeArgs, passthroughArgs)
 
+  const plan: ScaffoldPlan = {
+    scaffolderName,
+    command: entry.command,
+    args: commandArgs,
+    prerequisites: entry.prerequisites,
+    resolvedFlags: breakdown,
+    versionUsed,
+    upstreamVersion,
+  }
+
+  // 6. Dry run: return the plan with zero side effects (no prereq enforcement, no spawn).
+  if (dryRun) {
+    return plan
+  }
+
+  // 7. Enforce prerequisites, then spawn with inherited stdio (UX-06).
+  // Version is detected earlier (needed to build the plan), but we keep the
+  // user-facing log order identical to the pre-dry-run behavior:
+  // prerequisites -> detected version -> flag mappings -> running.
+  tinkeriseLog('Checking prerequisites...')
+  await checkPrerequisites(entry.prerequisites)
+
+  if (upstreamVersion) {
+    tinkeriseLog(`Detected ${entry.packageName} v${upstreamVersion}`)
+  }
+  if (versionUsed) {
+    tinkeriseLog(`Using flag mappings for version range ${versionUsed}`)
+  }
   tinkeriseLog(`Running ${entry.command} ${commandArgs.join(' ')}`)
   tinkeriseBlankLine()
 
-  // 7. Spawn with inherited stdio (UX-06)
   const result = await spawnScaffolder(entry.command, commandArgs, { cwd })
 
   tinkeriseBlankLine()
@@ -92,6 +131,7 @@ export async function executeScaffolder(options: ExecuteOptions): Promise<void> 
 
   // Note: Summary output is handled by the CLI layer (tinkeriseSummaryCard)
   // for the enhanced post-scaffold experience.
+  return plan
 }
 
 /**

--- a/packages/core/src/flags/__tests__/resolver.test.ts
+++ b/packages/core/src/flags/__tests__/resolver.test.ts
@@ -32,7 +32,7 @@ describe('resolveFlags breakdown', () => {
   })
 
   it('attributes prefix-style value flags while preserving flat arg order', () => {
-    const result = resolveFlags({ entry, userFlags: { typescript: true, 'package-manager': 'pnpm' } })
+    const result = resolveFlags({ entry, userFlags: { 'typescript': true, 'package-manager': 'pnpm' } })
 
     expect(result.args).toEqual(['--typescript', '--use-pnpm'])
     expect(result.breakdown).toEqual([

--- a/packages/core/src/flags/__tests__/resolver.test.ts
+++ b/packages/core/src/flags/__tests__/resolver.test.ts
@@ -1,0 +1,57 @@
+import type { ScaffolderEntry } from '@tinkerise/shared'
+import { describe, expect, it } from 'vitest'
+import { resolveFlags } from '../resolver.js'
+
+const entry: ScaffolderEntry = {
+  name: 'next',
+  category: 'web',
+  command: 'npx',
+  packageName: 'create-next-app',
+  integration: { type: 'delegate', command: 'create-next-app@latest' },
+  prerequisites: [],
+  flags: [
+    { unified: 'typescript', native: '--typescript' },
+    { unified: 'tailwind', native: '--tailwind' },
+    { unified: 'package-manager', native: '--use-', valueMap: { pnpm: 'pnpm', yarn: 'yarn' } },
+    { unified: 'git', native: '--git', nativeDisable: '--no-git' },
+    // Empty-string sentinel: a flag that upstream enables by default (no-op native).
+    { unified: 'silent', native: '' },
+  ],
+  passthroughArgs: true,
+}
+
+describe('resolveFlags breakdown', () => {
+  it('returns a per-flag native breakdown alongside flat args', () => {
+    const result = resolveFlags({ entry, userFlags: { typescript: true, tailwind: true } })
+
+    expect(result.args).toEqual(['--typescript', '--tailwind'])
+    expect(result.breakdown).toEqual([
+      { unified: 'typescript', native: ['--typescript'] },
+      { unified: 'tailwind', native: ['--tailwind'] },
+    ])
+  })
+
+  it('attributes prefix-style value flags while preserving flat arg order', () => {
+    const result = resolveFlags({ entry, userFlags: { typescript: true, 'package-manager': 'pnpm' } })
+
+    expect(result.args).toEqual(['--typescript', '--use-pnpm'])
+    expect(result.breakdown).toEqual([
+      { unified: 'typescript', native: ['--typescript'] },
+      { unified: 'package-manager', native: ['--use-pnpm'] },
+    ])
+  })
+
+  it('attributes negation flags when a flag is explicitly disabled', () => {
+    const result = resolveFlags({ entry, userFlags: { git: false } })
+
+    expect(result.args).toEqual(['--no-git'])
+    expect(result.breakdown).toEqual([{ unified: 'git', native: ['--no-git'] }])
+  })
+
+  it('omits silent/no-op flags (empty native) from args and breakdown', () => {
+    const result = resolveFlags({ entry, userFlags: { silent: true } })
+
+    expect(result.args).toEqual([])
+    expect(result.breakdown).toEqual([])
+  })
+})

--- a/packages/core/src/flags/index.ts
+++ b/packages/core/src/flags/index.ts
@@ -3,5 +3,5 @@
  */
 
 export { resolveFlags } from './resolver.js'
-export type { ResolveFlagsOptions, ResolveFlagsResult } from './resolver.js'
+export type { ResolvedFlagMapping, ResolveFlagsOptions, ResolveFlagsResult } from './resolver.js'
 export { FlagNotApplicableError, validateFlagApplicability } from './validator.js'

--- a/packages/core/src/flags/resolver.ts
+++ b/packages/core/src/flags/resolver.ts
@@ -15,11 +15,20 @@ export interface ResolveFlagsOptions {
   upstreamVersion?: string | null
 }
 
+export interface ResolvedFlagMapping {
+  /** Unified flag name, e.g., 'typescript' */
+  unified: string
+  /** Native args this flag produced, e.g., ['--typescript'] */
+  native: string[]
+}
+
 export interface ResolveFlagsResult {
   /** Native CLI args to pass to the upstream tool */
   args: string[]
   /** Which version range matched (null = base flags used) */
   versionUsed: string | null
+  /** Per-flag attribution: which native args each unified flag produced (for --explain) */
+  breakdown: ResolvedFlagMapping[]
 }
 
 /**
@@ -45,24 +54,25 @@ export function resolveFlags(options: ResolveFlagsOptions): ResolveFlagsResult {
     }
   }
 
-  // Map unified flags to native args
+  // Map unified flags to native args, attributing each flag's output for --explain.
   const args: string[] = []
+  const breakdown: ResolvedFlagMapping[] = []
   for (const flagDef of activeFlagDefs) {
     const userValue = userFlags[flagDef.unified]
     if (userValue === undefined)
       continue
 
+    const nativeForFlag: string[] = []
     if (userValue === false && flagDef.nativeDisable) {
       // User explicitly disabled (e.g., --no-typescript)
-      if (flagDef.nativeDisable)
-        args.push(...flagDef.nativeDisable.split(/\s+/))
+      nativeForFlag.push(...flagDef.nativeDisable.split(/\s+/))
     }
     else if (userValue === true) {
       // Split on whitespace to handle multi-word native flags
       // e.g., '--add tailwindcss' -> ['--add', 'tailwindcss']
       // Empty string sentinel (silent/no-op flags) produces no args
       if (flagDef.native)
-        args.push(...flagDef.native.split(/\s+/))
+        nativeForFlag.push(...flagDef.native.split(/\s+/))
     }
     else if (typeof userValue === 'string' && flagDef.valueMap) {
       // Value flag with mapping (e.g., --package-manager pnpm)
@@ -70,17 +80,23 @@ export function resolveFlags(options: ResolveFlagsOptions): ResolveFlagsResult {
       if (mapped) {
         // Prefix-style: '--use-' + 'pnpm' = '--use-pnpm'
         if (flagDef.native.endsWith('-')) {
-          args.push(`${flagDef.native}${mapped}`)
+          nativeForFlag.push(`${flagDef.native}${mapped}`)
         }
         else {
-          args.push(...flagDef.native.split(/\s+/), mapped)
+          nativeForFlag.push(...flagDef.native.split(/\s+/), mapped)
         }
       }
     }
     else if (typeof userValue === 'string') {
-      args.push(...flagDef.native.split(/\s+/), userValue)
+      nativeForFlag.push(...flagDef.native.split(/\s+/), userValue)
+    }
+
+    // Only record flags that actually produced native args (preserves flat-arg order).
+    if (nativeForFlag.length > 0) {
+      args.push(...nativeForFlag)
+      breakdown.push({ unified: flagDef.unified, native: nativeForFlag })
     }
   }
 
-  return { args, versionUsed }
+  return { args, versionUsed, breakdown }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,7 @@ export {
   tinkeriseLog,
   tinkeriseSummaryCard,
 } from './executor/index.js'
-export type { ExecuteOptions } from './executor/index.js'
+export type { ExecuteOptions, ScaffoldPlan } from './executor/index.js'
 
 /**
  * Flags — unified-to-native flag mapping and validation.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -52,6 +52,10 @@ export {
   PresetListPayloadV1Schema,
   PresetShowDataV1Schema,
   PresetShowEnvelopeV1Schema,
+  ScaffoldPlanEnvelopeV1Schema,
+  ScaffoldPlanFlagSchema,
+  ScaffoldPlanPayloadV1Schema,
+  ScaffoldPlanPrerequisiteSchema,
 } from './json-output/index.js'
 
 export type {
@@ -64,6 +68,8 @@ export type {
   PresetListPayloadV1,
   PresetShowEnvelopeV1,
   PresetShowPayloadV1,
+  ScaffoldPlanEnvelopeV1,
+  ScaffoldPlanPayloadV1,
 } from './json-output/index.js'
 
 /**

--- a/packages/shared/src/json-output/index.ts
+++ b/packages/shared/src/json-output/index.ts
@@ -39,3 +39,10 @@ export {
   PresetShowEnvelopeV1Schema,
 } from './preset-show.js'
 export type { PresetShowEnvelopeV1, PresetShowPayloadV1 } from './preset-show.js'
+export {
+  ScaffoldPlanEnvelopeV1Schema,
+  ScaffoldPlanFlagSchema,
+  ScaffoldPlanPayloadV1Schema,
+  ScaffoldPlanPrerequisiteSchema,
+} from './scaffold-plan.js'
+export type { ScaffoldPlanEnvelopeV1, ScaffoldPlanPayloadV1 } from './scaffold-plan.js'

--- a/packages/shared/src/json-output/scaffold-plan.ts
+++ b/packages/shared/src/json-output/scaffold-plan.ts
@@ -1,0 +1,45 @@
+/**
+ * `tinkerise … --dry-run --json` payload schema (v1).
+ *
+ * Mirrors the core ScaffoldPlan: the exact upstream command tinkerise would run,
+ * plus the per-flag unified→native breakdown and prerequisites (for --explain).
+ */
+
+import { z } from 'zod'
+import { makeEnvelope } from './envelope.js'
+
+export const ScaffoldPlanFlagSchema = z.object({
+  /** Unified tinkerise flag name, e.g. 'typescript' */
+  unified: z.string(),
+  /** Native args this flag produced, e.g. ['--typescript'] */
+  native: z.array(z.string()),
+})
+
+export const ScaffoldPlanPrerequisiteSchema = z.object({
+  /** Executable name, e.g. 'node' */
+  command: z.string(),
+  /** Semver range, e.g. '>=20.11.0' (omitted when unversioned) */
+  versionRange: z.string().nullish(),
+})
+
+export const ScaffoldPlanPayloadV1Schema = z.object({
+  /** Scaffolder ID, e.g. 'next' */
+  scaffolderName: z.string(),
+  /** Executable to invoke, e.g. 'npx' */
+  command: z.string(),
+  /** Full argument vector passed to the executable */
+  args: z.array(z.string()),
+  /** Per-flag unified→native attribution */
+  resolvedFlags: z.array(ScaffoldPlanFlagSchema),
+  /** Version range whose flag mappings were used (null = base flags) */
+  versionUsed: z.string().nullable(),
+  /** Detected upstream tool version (null when undetected/absent) */
+  upstreamVersion: z.string().nullable(),
+  /** Prerequisites that would be enforced before a real run */
+  prerequisites: z.array(ScaffoldPlanPrerequisiteSchema),
+})
+
+export const ScaffoldPlanEnvelopeV1Schema = makeEnvelope('scaffold.plan', ScaffoldPlanPayloadV1Schema, 1)
+
+export type ScaffoldPlanPayloadV1 = z.infer<typeof ScaffoldPlanPayloadV1Schema>
+export type ScaffoldPlanEnvelopeV1 = z.infer<typeof ScaffoldPlanEnvelopeV1Schema>

--- a/packages/shared/tests/json-output/schemas.test.ts
+++ b/packages/shared/tests/json-output/schemas.test.ts
@@ -7,6 +7,7 @@ import {
   makeEnvelope,
   PresetListEnvelopeV1Schema,
   PresetShowEnvelopeV1Schema,
+  ScaffoldPlanEnvelopeV1Schema,
 } from '../../src/index'
 
 describe('errorPayloadSchema', () => {
@@ -420,6 +421,84 @@ describe('presetShowEnvelopeV1Schema', () => {
         enhancements: [],
         config: {},
       },
+    }).success).toBe(false)
+  })
+})
+
+describe('scaffoldPlanEnvelopeV1Schema', () => {
+  const fullData = {
+    scaffolderName: 'next',
+    command: 'npx',
+    args: ['create-next-app@latest', 'my-app', '--typescript'],
+    resolvedFlags: [{ unified: 'typescript', native: ['--typescript'] }],
+    versionUsed: null,
+    upstreamVersion: '15.0.0',
+    prerequisites: [{ command: 'node', versionRange: '>=20.11.0' }],
+  }
+
+  it('parses a fully-populated plan payload', () => {
+    const result = ScaffoldPlanEnvelopeV1Schema.parse({
+      schemaVersion: 1,
+      command: 'scaffold.plan',
+      data: fullData,
+    })
+
+    expect('data' in result && result.data.command).toBe('npx')
+    expect('data' in result && result.data.resolvedFlags[0]?.native).toEqual(['--typescript'])
+  })
+
+  it('accepts empty flags/prereqs and null versions (D-21)', () => {
+    const result = ScaffoldPlanEnvelopeV1Schema.parse({
+      schemaVersion: 1,
+      command: 'scaffold.plan',
+      data: {
+        scaffolderName: 'go',
+        command: 'go-blueprint',
+        args: ['create', 'my-app'],
+        resolvedFlags: [],
+        versionUsed: null,
+        upstreamVersion: null,
+        prerequisites: [],
+      },
+    })
+
+    expect('data' in result && result.data.resolvedFlags).toEqual([])
+  })
+
+  it('accepts a prerequisite with omitted versionRange (D-22)', () => {
+    const result = ScaffoldPlanEnvelopeV1Schema.parse({
+      schemaVersion: 1,
+      command: 'scaffold.plan',
+      data: { ...fullData, prerequisites: [{ command: 'node' }] },
+    })
+
+    const data = 'data' in result ? result.data : undefined
+    expect(data?.prerequisites[0]?.versionRange).toBeUndefined()
+  })
+
+  it('accepts the error variant', () => {
+    const result = ScaffoldPlanEnvelopeV1Schema.parse({
+      schemaVersion: 1,
+      command: 'scaffold.plan',
+      error: { code: 'SCAFFOLDER_NOT_FOUND', message: 'no such scaffolder' },
+    })
+
+    expect('error' in result && result.error.code).toBe('SCAFFOLDER_NOT_FOUND')
+  })
+
+  it('rejects wrong command literal', () => {
+    expect(ScaffoldPlanEnvelopeV1Schema.safeParse({
+      schemaVersion: 1,
+      command: 'scaffold',
+      data: fullData,
+    }).success).toBe(false)
+  })
+
+  it('rejects wrong schemaVersion', () => {
+    expect(ScaffoldPlanEnvelopeV1Schema.safeParse({
+      schemaVersion: 2,
+      command: 'scaffold.plan',
+      data: fullData,
     }).success).toBe(false)
   })
 })


### PR DESCRIPTION
Preview the exact upstream scaffolder command without executing.

- \`--dry-run\` — print the resolved \`npx …\` command; writes nothing
- \`--explain\` — also show the unified→native flag breakdown and prerequisites
- \`--json --dry-run\` — emit a validated \`scaffold.plan\` envelope for tooling/agents
- vite/t3 + \`--json --dry-run\` that would need a variant prompt fail loudly with \`INTERACTIVE_PROMPT_BLOCKED\` (no corrupted output)

Implementation: \`executeScaffolder\` builds a \`ScaffoldPlan\` and returns it before any side effect when \`dryRun\` is set (no prereq enforcement, no spawn); the CLI renders it.

Verified: lint, typecheck, build green; tests 1181 pass (core 661, shared 79, cli 441) + end-to-end smoke of all four paths.