### PR TITLE
fix(cli): cross-platform CI — Windows preset path + fish 4.x completion

### DIFF
--- a/.changeset/fish-completion-fixes.md
+++ b/.changeset/fish-completion-fixes.md
@@ -1,0 +1,5 @@
+---
+"@tinkerise/cli": patch
+---
+
+Fix fish shell completion under fish 4.x: complete global flags after subcommands, suppress file fallback for unknown commands, and complete value flags (e.g. `--preset`) without leaking subcommand names.

--- a/packages/cli/src/completion/fish.ts
+++ b/packages/cli/src/completion/fish.ts
@@ -68,6 +68,8 @@ function emitBlock(binary: 'tinkerise' | 'tk', root: CommandNode): string[] {
   const topLevel = collectTopLevelCandidates(root)
 
   lines.push(`# --- Completions for ${binary} ---`)
+  // Disable file fallback so unknown/failed contexts yield no candidates (D-19)
+  lines.push(`complete -c ${binary} -f`)
 
   // Top-level subcommand + root-positional candidates (web/backend/mobile + subcommand names)
   const rootPositional = POSITIONAL_ENUMS['']
@@ -89,23 +91,29 @@ function emitBlock(binary: 'tinkerise' | 'tk', root: CommandNode): string[] {
     lines.push(`complete -c ${binary} -f -n '__fish_seen_subcommand_from ${escapeSingle(category)}' -a '(tinkerise __complete ${dynKind} 2>/dev/null; or true)'`)
   }
 
-  // Top-level flag-name completion (with -- prefix)
+  // Root flags are global (complete at any depth, like bash/zsh). Value flags use a
+  // single -r directive carrying their candidates so fish completes the value (not
+  // subcommands) and suppresses file fallback on a failed lookup (D-19); boolean flags
+  // only complete the name.
+  const valueFlagNames = new Set(
+    [...Object.keys(FLAG_ENUMS), ...Object.keys(DYNAMIC_FLAGS)].map(f => f.replace(/^--/, '')),
+  )
+
   for (const flag of root.flags) {
     const flagName = flag.replace(/^--/, '')
-    lines.push(`complete -c ${binary} -f -n '__fish_use_subcommand' -l '${escapeSingle(flagName)}'`)
+    if (!valueFlagNames.has(flagName))
+      lines.push(`complete -c ${binary} -f -l '${escapeSingle(flagName)}'`)
   }
 
-  // Flag-value completion: static enums
   for (const [flag, values] of Object.entries(FLAG_ENUMS)) {
     const flagName = flag.replace(/^--/, '')
-    lines.push(`complete -c ${binary} -f -n '__fish_seen_argument -l ${escapeSingle(flagName)}' -a '${joinSpace(values)}'`)
+    lines.push(`complete -c ${binary} -f -r -l '${escapeSingle(flagName)}' -a '${joinSpace(values)}'`)
   }
 
-  // Flag-value completion: dynamic lookups
   for (const flag of Object.keys(DYNAMIC_FLAGS)) {
     const kind = DYNAMIC_FLAGS[flag]!
     const flagName = flag.replace(/^--/, '')
-    lines.push(`complete -c ${binary} -f -n '__fish_seen_argument -l ${escapeSingle(flagName)}' -a '(tinkerise __complete ${kind} 2>/dev/null; or true)'`)
+    lines.push(`complete -c ${binary} -f -r -l '${escapeSingle(flagName)}' -a '(tinkerise __complete ${kind} 2>/dev/null; or true)'`)
   }
 
   // Per-subcommand completions

--- a/packages/cli/tests/commands/preset.test.ts
+++ b/packages/cli/tests/commands/preset.test.ts
@@ -17,8 +17,9 @@
  * - preset delete nonexistent shows "not found" error
  */
 
-import { Command } from 'commander'
+import { join } from 'node:path'
 
+import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerPresetCommand } from '../../src/commands/preset.js'
 
@@ -771,7 +772,7 @@ describe('preset show <name> --json (CLI-14, D-06/D-07/D-08)', () => {
     expect(envelope.data.name).toBe('my-stack')
     expect(envelope.data.description).toBe('My stack preset')
     expect(envelope.data.source).toBe('local')
-    expect(envelope.data.filePath).toBe('/home/user/.config/tinkerise/presets/my-stack.json')
+    expect(envelope.data.filePath).toBe(join('/home/user/.config/tinkerise/presets', 'my-stack.json'))
     expect(envelope.data.scaffold).toEqual({ framework: 'next', category: 'web', flags: { typescript: true } })
     expect(envelope.data.enhancements).toEqual(['eslint', 'prettier'])
     expect(envelope.data.config).toEqual({ packageManager: 'pnpm' })

--- a/packages/cli/tests/unit/completion/__snapshots__/fish.test.ts.snap
+++ b/packages/cli/tests/unit/completion/__snapshots__/fish.test.ts.snap
@@ -6,28 +6,26 @@ exports[`completion/fish.generate > emits a stable script for the fixture Comman
 # Install via: tinkerise completion fish > ~/.config/fish/completions/tinkerise.fish
 
 # --- Completions for tinkerise ---
+complete -c tinkerise -f
 complete -c tinkerise -f -n '__fish_use_subcommand' -a 'web backend mobile list add install doctor completion'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from web' -a '(tinkerise __complete scaffolders:web 2>/dev/null; or true)'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from backend' -a '(tinkerise __complete scaffolders:backend 2>/dev/null; or true)'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from mobile' -a '(tinkerise __complete scaffolders:mobile 2>/dev/null; or true)'
-complete -c tinkerise -f -n '__fish_use_subcommand' -l 'package-manager'
-complete -c tinkerise -f -n '__fish_use_subcommand' -l 'preset'
-complete -c tinkerise -f -n '__fish_seen_argument -l package-manager' -a 'npm pnpm yarn bun'
-complete -c tinkerise -f -n '__fish_seen_argument -l preset' -a '(tinkerise __complete presets 2>/dev/null; or true)'
+complete -c tinkerise -f -r -l 'package-manager' -a 'npm pnpm yarn bun'
+complete -c tinkerise -f -r -l 'preset' -a '(tinkerise __complete presets 2>/dev/null; or true)'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from list' -a 'web backend mobile'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from add' -a '(tinkerise __complete enhancements 2>/dev/null; or true)'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from install' -a '(tinkerise __complete enhancements 2>/dev/null; or true)'
 complete -c tinkerise -f -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish'
 
 # --- Completions for tk ---
+complete -c tk -f
 complete -c tk -f -n '__fish_use_subcommand' -a 'web backend mobile list add install doctor completion'
 complete -c tk -f -n '__fish_seen_subcommand_from web' -a '(tinkerise __complete scaffolders:web 2>/dev/null; or true)'
 complete -c tk -f -n '__fish_seen_subcommand_from backend' -a '(tinkerise __complete scaffolders:backend 2>/dev/null; or true)'
 complete -c tk -f -n '__fish_seen_subcommand_from mobile' -a '(tinkerise __complete scaffolders:mobile 2>/dev/null; or true)'
-complete -c tk -f -n '__fish_use_subcommand' -l 'package-manager'
-complete -c tk -f -n '__fish_use_subcommand' -l 'preset'
-complete -c tk -f -n '__fish_seen_argument -l package-manager' -a 'npm pnpm yarn bun'
-complete -c tk -f -n '__fish_seen_argument -l preset' -a '(tinkerise __complete presets 2>/dev/null; or true)'
+complete -c tk -f -r -l 'package-manager' -a 'npm pnpm yarn bun'
+complete -c tk -f -r -l 'preset' -a '(tinkerise __complete presets 2>/dev/null; or true)'
 complete -c tk -f -n '__fish_seen_subcommand_from list' -a 'web backend mobile'
 complete -c tk -f -n '__fish_seen_subcommand_from add' -a '(tinkerise __complete enhancements 2>/dev/null; or true)'
 complete -c tk -f -n '__fish_seen_subcommand_from install' -a '(tinkerise __complete enhancements 2>/dev/null; or true)'


### PR DESCRIPTION
Fixes the pre-existing CI failures on `main` (Reliability Gates + windows-latest).

**Windows** — `preset.show` test hard-coded a forward-slash `filePath`; build the expected value with `path.join` so it matches the native OS path.

**fish 4.x completion** (Reliability Gates) — three conformance scenarios failed because the generated script:
- restricted global flags to top level (`__fish_use_subcommand`) → now completes them at any depth, like bash/zsh
- had no file-completion baseline → unknown commands listed cwd files; added `complete -c <cmd> -f`
- registered value flags without `-r` → `--preset <TAB>` leaked subcommand names; now a single `-r` directive carries the value candidates

Verified locally with fish 4.7.1: all bash/zsh/fish completion conformance scenarios pass. Full gate green (lint, typecheck, build, tests).