### PR TITLE
feat(cli): natural-language stack tokens

### DIFF
--- a/.changeset/nl-stack-tokens.md
+++ b/.changeset/nl-stack-tokens.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/core": minor
+---
+
+Add natural-language stack tokens: `tinkerise my-app next ts tailwind eslint`. Tokens are classified into framework, scaffold flags, and enhancements; unknown tokens get a "did you mean?" suggestion. The existing `[category] [framework] [name]` form is unchanged.

--- a/packages/cli/src/commands/stack.ts
+++ b/packages/cli/src/commands/stack.ts
@@ -1,0 +1,70 @@
+import type { Command } from 'commander'
+import type { ScaffoldOptions } from './scaffold.js'
+import { enhancementRegistry, findClosestMatch, getAllScaffolders, parseStackTokens } from '@tinkerise/core'
+import { runDirectExecution } from './scaffold.js'
+
+type BoolOption
+  = | 'typescript' | 'tailwind' | 'biome' | 'srcDir' | 'appRouter'
+    | 'empty' | 'overwrite' | 'api' | 'turbopack' | 'reactCompiler'
+
+// Parser emits kebab-case canonical flags; ScaffoldOptions reads camelCase fields.
+const FLAG_TO_OPTION: Record<string, BoolOption> = {
+  'typescript': 'typescript',
+  'tailwind': 'tailwind',
+  'biome': 'biome',
+  'src-dir': 'srcDir',
+  'app-router': 'appRouter',
+  'empty': 'empty',
+  'overwrite': 'overwrite',
+  'api': 'api',
+  'turbopack': 'turbopack',
+  'react-compiler': 'reactCompiler',
+}
+
+export interface StackResolution {
+  framework: string
+  category: string
+  name?: string
+  preselected: string[]
+  enhancements: string[]
+  unknown: string[]
+}
+
+export function tokensToScaffold(tokens: string[]): StackResolution {
+  const frameworks = getAllScaffolders().map(s => ({ name: s.name, category: s.category }))
+  const enhancementIds = [...enhancementRegistry.keys()]
+  const parsed = parseStackTokens(tokens, { frameworks, enhancementIds })
+
+  if (parsed.unknown.length > 0) {
+    const bad = parsed.unknown[0]!
+    const suggestion = findClosestMatch(bad, [...frameworks.map(f => f.name), ...enhancementIds, 'typescript', 'tailwind', 'biome'])
+    throw new Error(suggestion ? `Unknown token '${bad}'. Did you mean '${suggestion}'?` : `Unknown token '${bad}'.`)
+  }
+
+  if (!parsed.framework)
+    throw new Error(`Could not identify a framework in: ${tokens.join(' ')}`)
+
+  return {
+    framework: parsed.framework,
+    category: parsed.category!,
+    name: parsed.name,
+    preselected: Object.keys(parsed.flags).filter(k => parsed.flags[k]),
+    enhancements: parsed.enhancements,
+    unknown: parsed.unknown,
+  }
+}
+
+export async function runStackMode(tokens: string[], cmd: Command, options: ScaffoldOptions): Promise<void> {
+  const r = tokensToScaffold(tokens)
+
+  for (const flag of r.preselected) {
+    const key = FLAG_TO_OPTION[flag]
+    if (key)
+      options[key] = true
+  }
+
+  await runDirectExecution(r.category, r.framework, r.name, cmd, options)
+
+  if (r.enhancements.length > 0)
+    process.stdout.write(`\nNext: add your enhancements\n  tinkerise add ${r.enhancements.join(' ')}\n`)
+}

--- a/packages/cli/src/commands/stack.ts
+++ b/packages/cli/src/commands/stack.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander'
 import type { ScaffoldOptions } from './scaffold.js'
-import { enhancementRegistry, findClosestMatch, getAllScaffolders, parseStackTokens } from '@tinkerise/core'
+import { enhancementRegistry, findClosestMatch, getAllScaffolders, InvalidStackTokensError, parseStackTokens } from '@tinkerise/core'
 import { runDirectExecution } from './scaffold.js'
 
 type BoolOption
@@ -38,11 +38,11 @@ export function tokensToScaffold(tokens: string[]): StackResolution {
   if (parsed.unknown.length > 0) {
     const bad = parsed.unknown[0]!
     const suggestion = findClosestMatch(bad, [...frameworks.map(f => f.name), ...enhancementIds, 'typescript', 'tailwind', 'biome'])
-    throw new Error(suggestion ? `Unknown token '${bad}'. Did you mean '${suggestion}'?` : `Unknown token '${bad}'.`)
+    throw new InvalidStackTokensError(`Unknown token '${bad}'.`, suggestion ? `Did you mean '${suggestion}'?` : undefined)
   }
 
   if (!parsed.framework)
-    throw new Error(`Could not identify a framework in: ${tokens.join(' ')}`)
+    throw new InvalidStackTokensError(`Could not identify a framework in: ${tokens.join(' ')}`)
 
   return {
     framework: parsed.framework,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -90,26 +90,38 @@ program
   .option('--dry-run', 'Show the command that would run without executing')
   .option('--explain', 'Like --dry-run, plus flag and prerequisite details (implies --dry-run)')
 
+const VALID_CATEGORIES = ['web', 'backend', 'mobile']
+
 // Default action with optional positional arguments
 program
-  .argument('[category]', 'Project category (web, backend, mobile)')
-  .argument('[framework]', 'Framework name')
-  .argument('[name]', 'Project name')
-  .action(async (category: string | undefined, framework: string | undefined, name: string | undefined, options, command) => {
+  .argument('[category]', 'Project category (web, backend, mobile) — or first stack token')
+  .argument('[framework]', 'Framework name — or stack token')
+  .argument('[name]', 'Project name — or stack token')
+  .argument('[tokens...]', 'Additional natural-language stack tokens')
+  .action(async (category: string | undefined, framework: string | undefined, name: string | undefined, tokens: string[], options, command) => {
     // Merge --ts alias into --typescript
     if (options.ts) {
       options.typescript = true
     }
 
-    if (!category) {
-      await runInteractiveFlow(command, options)
+    // Existing positional contract: first arg is a known category.
+    if (!category || VALID_CATEGORIES.includes(category)) {
+      if (!category) {
+        await runInteractiveFlow(command, options)
+      }
+      else if (!framework) {
+        await runCategoryFlow(category, command, options)
+      }
+      else {
+        await runDirectExecution(category, framework, name, command, options)
+      }
+      return
     }
-    else if (!framework) {
-      await runCategoryFlow(category, command, options)
-    }
-    else {
-      await runDirectExecution(category, framework, name, command, options)
-    }
+
+    // Natural-language stack mode: first token is not a category.
+    const allTokens = [category, framework, name, ...(tokens ?? [])].filter(Boolean) as string[]
+    const { runStackMode } = await import('./commands/stack.js')
+    await runStackMode(allTokens, command, options)
   })
 
 // List command — shows all scaffolders grouped by category
@@ -206,6 +218,7 @@ Examples:
   $ ${programName} web                        Select from web frameworks
   $ ${programName} web next my-app            Create a Next.js project
   $ ${programName} web vite my-app --ts       Create with TypeScript
+  $ ${programName} my-app next ts tailwind    Natural-language stack tokens
   $ ${programName} monorepo my-repo           Create a Turborepo monorepo
   $ ${programName} list                       Show available scaffolders
   $ ${programName} list web                   Show web scaffolders with details
@@ -229,7 +242,6 @@ Examples:
 // Per-scaffolder help interception (before Commander processes --help)
 // Detects: tinkerise web <framework> --help | -h
 // Shows unified-only flags per locked decision, then exits.
-const VALID_CATEGORIES = ['web', 'backend', 'mobile']
 const userArgs = process.argv.slice(2)
 const helpIdx = userArgs.findIndex(a => a === '--help' || a === '-h')
 try {

--- a/packages/cli/tests/commands/stack.test.ts
+++ b/packages/cli/tests/commands/stack.test.ts
@@ -17,12 +17,27 @@ describe('tokensToScaffold', () => {
     expect(r.enhancements).toEqual(['eslint'])
   })
 
-  it('throws a did-you-mean error on an unknown token', () => {
-    expect(() => tokensToScaffold(['my-app', 'nextt'])).toThrow(/did you mean/i)
+  it('throws InvalidStackTokensError with a suggestion on an unknown token', () => {
+    let err: any
+    try {
+      tokensToScaffold(['my-app', 'nextt'])
+    }
+    catch (e) {
+      err = e
+    }
+    expect(err?.code).toBe('INVALID_STACK_TOKENS')
+    expect(err?.suggestion).toMatch(/next/)
   })
 
-  it('throws when no framework is resolved', () => {
-    expect(() => tokensToScaffold(['my-app', 'ts'])).toThrow(/framework/i)
+  it('throws InvalidStackTokensError when no framework is resolved', () => {
+    let err: any
+    try {
+      tokensToScaffold(['my-app', 'ts'])
+    }
+    catch (e) {
+      err = e
+    }
+    expect(err?.code).toBe('INVALID_STACK_TOKENS')
   })
 })
 

--- a/packages/cli/tests/commands/stack.test.ts
+++ b/packages/cli/tests/commands/stack.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockRunDirectExecution = vi.hoisted(() => vi.fn())
+vi.mock('../../src/commands/scaffold.js', () => ({
+  runDirectExecution: mockRunDirectExecution,
+}))
+
+const { runStackMode, tokensToScaffold } = await import('../../src/commands/stack.js')
+
+describe('tokensToScaffold', () => {
+  it('maps tokens to framework/category/name/preselected/enhancements', () => {
+    const r = tokensToScaffold(['my-app', 'next', 'ts', 'tailwind', 'eslint'])
+    expect(r.framework).toBe('next')
+    expect(r.category).toBe('web')
+    expect(r.name).toBe('my-app')
+    expect(r.preselected.sort()).toEqual(['tailwind', 'typescript'])
+    expect(r.enhancements).toEqual(['eslint'])
+  })
+
+  it('throws a did-you-mean error on an unknown token', () => {
+    expect(() => tokensToScaffold(['my-app', 'nextt'])).toThrow(/did you mean/i)
+  })
+
+  it('throws when no framework is resolved', () => {
+    expect(() => tokensToScaffold(['my-app', 'ts'])).toThrow(/framework/i)
+  })
+})
+
+describe('runStackMode', () => {
+  it('folds kebab-case flags onto camelCase options and calls runDirectExecution', async () => {
+    mockRunDirectExecution.mockClear()
+    const options: any = {}
+    await runStackMode(['my-app', 'next', 'src-dir', 'app-router'], {} as any, options)
+
+    expect(options.srcDir).toBe(true)
+    expect(options.appRouter).toBe(true)
+    expect(mockRunDirectExecution).toHaveBeenCalledWith('web', 'next', 'my-app', expect.anything(), options)
+  })
+})

--- a/packages/core/src/errors/base.ts
+++ b/packages/core/src/errors/base.ts
@@ -263,3 +263,18 @@ export class UnknownShellError extends TinkeriseError {
     this.name = 'UnknownShellError'
   }
 }
+
+/**
+ * Thrown when natural-language stack tokens cannot be resolved (unknown token
+ * or no framework identified).
+ */
+export class InvalidStackTokensError extends TinkeriseError {
+  constructor(message: string, suggestion?: string) {
+    super({
+      message,
+      code: 'INVALID_STACK_TOKENS',
+      suggestion,
+    })
+    this.name = 'InvalidStackTokensError'
+  }
+}

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -10,6 +10,7 @@ export {
   InteractivePromptBlockedError,
   InvalidCategoryError,
   InvalidConfigKeyError,
+  InvalidStackTokensError,
   JsonUnsupportedCommandError,
   PrerequisiteError,
   PresetNotFoundError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export {
   InteractivePromptBlockedError,
   InvalidCategoryError,
   InvalidConfigKeyError,
+  InvalidStackTokensError,
   JsonUnsupportedCommandError,
   PresetNotFoundError,
   TinkeriseError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,3 +178,9 @@ export type { ScaffolderMetadata } from './registry/metadata.js'
  */
 export { generateCliTool, generateLib, generateMcpServer, TEMPLATE_METADATA } from './templates/index.js'
 export type { TemplateOptions } from './templates/index.js'
+
+/**
+ * Tokens — natural-language stack token parser.
+ */
+export { parseStackTokens } from './tokens/index.js'
+export type { FrameworkVocab, ParsedStack, ParseRegistries } from './tokens/index.js'

--- a/packages/core/src/tokens/__tests__/parser.test.ts
+++ b/packages/core/src/tokens/__tests__/parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parseStackTokens } from '../parser.js'
+
+const reg = {
+  frameworks: [
+    { name: 'next', category: 'web' as const },
+    { name: 'vite', category: 'web' as const },
+  ],
+  enhancementIds: ['eslint', 'prettier', 'husky'],
+}
+
+describe('parseStackTokens', () => {
+  it('classifies name, framework, scaffold flags and enhancements', () => {
+    const r = parseStackTokens(['my-app', 'next', 'ts', 'tailwind', 'eslint'], reg)
+    expect(r.name).toBe('my-app')
+    expect(r.framework).toBe('next')
+    expect(r.category).toBe('web')
+    expect(r.flags).toEqual({ typescript: true, tailwind: true })
+    expect(r.enhancements).toEqual(['eslint'])
+    expect(r.unknown).toEqual([])
+  })
+
+  it('resolves framework aliases and is order-independent', () => {
+    const r = parseStackTokens(['nextjs', 'my-app'], reg)
+    expect(r.framework).toBe('next')
+    expect(r.name).toBe('my-app')
+  })
+
+  it('treats a second conflicting framework as unknown', () => {
+    const r = parseStackTokens(['my-app', 'next', 'vite'], reg)
+    expect(r.framework).toBe('next')
+    expect(r.unknown).toEqual(['vite'])
+  })
+
+  it('collects unknown tokens', () => {
+    const r = parseStackTokens(['my-app', 'next', 'flutterr'], reg)
+    expect(r.unknown).toEqual(['flutterr'])
+  })
+})

--- a/packages/core/src/tokens/index.ts
+++ b/packages/core/src/tokens/index.ts
@@ -1,0 +1,1 @@
+export * from './parser.js'

--- a/packages/core/src/tokens/parser.ts
+++ b/packages/core/src/tokens/parser.ts
@@ -1,0 +1,91 @@
+import type { ScaffolderCategory } from '@tinkerise/shared'
+
+const FRAMEWORK_ALIASES: Record<string, string> = {
+  'nextjs': 'next',
+  'react-native': 'rn',
+  'reactnative': 'rn',
+  'golang': 'go',
+  'fast-api': 'fastapi',
+}
+
+const SCAFFOLD_FLAG_ALIASES: Record<string, string> = {
+  'ts': 'typescript',
+  'typescript': 'typescript',
+  'tailwind': 'tailwind',
+  'tw': 'tailwind',
+  'biome': 'biome',
+  'src-dir': 'src-dir',
+  'srcdir': 'src-dir',
+  'app-router': 'app-router',
+  'approuter': 'app-router',
+  'empty': 'empty',
+  'overwrite': 'overwrite',
+  'api': 'api',
+  'turbopack': 'turbopack',
+  'react-compiler': 'react-compiler',
+}
+
+const NAME_RE = /^[a-z0-9._-]{1,64}$/
+
+export interface FrameworkVocab {
+  name: string
+  category: ScaffolderCategory
+}
+
+export interface ParseRegistries {
+  frameworks: FrameworkVocab[]
+  enhancementIds: string[]
+}
+
+export interface ParsedStack {
+  name?: string
+  framework?: string
+  category?: ScaffolderCategory
+  flags: Record<string, boolean>
+  enhancements: string[]
+  unknown: string[]
+}
+
+/** Classify each token: framework -> scaffold flag -> enhancement -> name -> unknown. */
+export function parseStackTokens(tokens: string[], reg: ParseRegistries): ParsedStack {
+  const fwByName = new Map(reg.frameworks.map(f => [f.name, f]))
+  const enhancements = new Set(reg.enhancementIds)
+  const result: ParsedStack = { flags: {}, enhancements: [], unknown: [] }
+
+  for (const raw of tokens) {
+    const token = raw.toLowerCase()
+
+    const fw = fwByName.get(FRAMEWORK_ALIASES[token] ?? token)
+    if (fw) {
+      if (!result.framework) {
+        result.framework = fw.name
+        result.category = fw.category
+      }
+      else if (result.framework !== fw.name) {
+        result.unknown.push(raw)
+      }
+      continue
+    }
+
+    const flag = SCAFFOLD_FLAG_ALIASES[token]
+    if (flag) {
+      result.flags[flag] = true
+      continue
+    }
+
+    if (enhancements.has(token)) {
+      if (!result.enhancements.includes(token))
+        result.enhancements.push(token)
+      continue
+    }
+
+    if (!result.name && NAME_RE.test(token)) {
+      result.name = token
+      continue
+    }
+
+    result.unknown.push(raw)
+  }
+
+  return result
+}


### PR DESCRIPTION
Scaffold by terse token stream: `tinkerise my-app next ts tailwind eslint`.

- Tokens are classified into framework, scaffold flags, and enhancements (pure `parseStackTokens` in core)
- Unknown tokens get a "did you mean?" suggestion via the existing fuzzy matcher
- Enhancement tokens are surfaced as a `tinkerise add <ids>` next-step (no cross-dir auto-apply)
- A variadic catch-all routes to NL mode only when the first arg is not `web|backend|mobile`; the existing `[category] [framework] [name]` contract is untouched

Verified: full gate green (lint, typecheck, build, tests 79+665+446); end-to-end smoke of backward-compat, NL mode, and the did-you-mean path (no dirs created in dry-run).