### PR TITLE
feat: record reproducible tinkerise.lock (Tier B foundation)

### DIFF
--- a/.changeset/tinkerise-lock.md
+++ b/.changeset/tinkerise-lock.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/shared": minor
+---
+
+Record a `tinkerise.lock` after each successful scaffold — a committed, schema-validated file capturing the framework, category, flags, package manager, and the tinkerise version used. This is the reproducible foundation for upcoming `--from-lock` and `tinkerise update` support.

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path'
 import * as p from '@clack/prompts'
 import { ConfigValidationError, detectPackageManager, executeScaffolder, findClosestMatch, InteractivePromptBlockedError, InvalidCategoryError, isCI, loadPreset, resolveConfig, tinkeriseSummaryCard } from '@tinkerise/core'
 import pc from 'picocolors'
+import { buildLock, LOCK_FILENAME, writeLockFile } from '../context/lock.js'
 import { setSessionContext, writeSessionFile } from '../context/session.js'
 import { runPromptFlow } from '../prompts/flow.js'
 import { promptPackageManager } from '../prompts/pm-select.js'
@@ -306,6 +307,15 @@ async function executePipeline(
   const absProjectPath = join(process.cwd(), name)
   setSessionContext({ framework, packageManager: pm, projectDir: absProjectPath })
   await writeSessionFile(absProjectPath, { framework, packageManager: pm })
+
+  // Persist the reproducible lock (committed artifact). Best-effort: a write
+  // failure must not fail an already-successful scaffold.
+  try {
+    await writeLockFile(absProjectPath, buildLock({ framework, flags: userFlags, packageManager: pm }))
+  }
+  catch {
+    p.log.warn(pc.yellow(`Could not write ${LOCK_FILENAME} (project created successfully)`))
+  }
 
   const activeFlags = Object.entries(userFlags)
     .filter(([, v]) => v === true)

--- a/packages/cli/src/context/lock.ts
+++ b/packages/cli/src/context/lock.ts
@@ -1,0 +1,51 @@
+/**
+ * tinkerise.lock — build and persist the reproducible record of a scaffold.
+ *
+ * Unlike the session file, the lock is a committed project artifact (the input
+ * for `scaffold --from-lock` and `tinkerise update`), so it is never gitignored.
+ */
+
+import type { LockEnhancement, TinkeriseLock } from '@tinkerise/shared'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getScaffolder } from '@tinkerise/core'
+import { LOCK_SCHEMA_VERSION, TinkeriseLockSchema, VERSION } from '@tinkerise/shared'
+
+/** Lock filename written to the scaffolded project root. */
+export const LOCK_FILENAME = 'tinkerise.lock'
+
+export interface BuildLockInput {
+  framework: string
+  flags: Record<string, string | boolean>
+  packageManager: string
+  enhancements?: LockEnhancement[]
+}
+
+/**
+ * Build a schema-validated lock for a scaffolded project. The category is
+ * derived from the registry so callers only need the framework.
+ */
+export function buildLock(input: BuildLockInput): TinkeriseLock {
+  const entry = getScaffolder(input.framework)
+  if (!entry)
+    throw new Error(`Cannot build lock: unknown framework '${input.framework}'`)
+
+  return TinkeriseLockSchema.parse({
+    schemaVersion: LOCK_SCHEMA_VERSION,
+    framework: input.framework,
+    category: entry.category,
+    flags: input.flags,
+    enhancements: input.enhancements ?? [],
+    packageManager: input.packageManager,
+    createdWith: VERSION,
+  })
+}
+
+/** Write the lock as pretty JSON to `tinkerise.lock` in the project directory. */
+export async function writeLockFile(projectDir: string, lock: TinkeriseLock): Promise<void> {
+  await writeFile(
+    join(projectDir, LOCK_FILENAME),
+    `${JSON.stringify(lock, null, 2)}\n`,
+    'utf-8',
+  )
+}

--- a/packages/cli/src/context/lock.ts
+++ b/packages/cli/src/context/lock.ts
@@ -5,7 +5,7 @@
  * for `scaffold --from-lock` and `tinkerise update`), so it is never gitignored.
  */
 
-import type { LockEnhancement, TinkeriseLock } from '@tinkerise/shared'
+import type { TinkeriseLock } from '@tinkerise/shared'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getScaffolder } from '@tinkerise/core'
@@ -18,7 +18,6 @@ export interface BuildLockInput {
   framework: string
   flags: Record<string, string | boolean>
   packageManager: string
-  enhancements?: LockEnhancement[]
 }
 
 /**
@@ -35,7 +34,7 @@ export function buildLock(input: BuildLockInput): TinkeriseLock {
     framework: input.framework,
     category: entry.category,
     flags: input.flags,
-    enhancements: input.enhancements ?? [],
+    enhancements: [],
     packageManager: input.packageManager,
     createdWith: VERSION,
   })

--- a/packages/cli/tests/commands/scaffold-config-preset.test.ts
+++ b/packages/cli/tests/commands/scaffold-config-preset.test.ts
@@ -90,6 +90,12 @@ vi.mock('@tinkerise/core', () => ({
   get isCI() { return mockIsCI.value },
 }))
 
+vi.mock('../../src/context/lock.js', () => ({
+  buildLock: vi.fn(() => ({})),
+  writeLockFile: vi.fn(),
+  LOCK_FILENAME: 'tinkerise.lock',
+}))
+
 vi.mock('../../src/prompts/variant-select.js', () => ({
   selectViteTemplate: mockSelectViteTemplate,
   resolveViteTemplate: mockResolveViteTemplate,

--- a/packages/cli/tests/commands/scaffold-wiring.test.ts
+++ b/packages/cli/tests/commands/scaffold-wiring.test.ts
@@ -34,6 +34,8 @@ const {
   mockSelectT3Components,
   mockResolveConfig,
   mockLoadPreset,
+  mockBuildLock,
+  mockWriteLockFile,
 } = vi.hoisted(() => ({
   mockShowBanner: vi.fn(),
   mockRunPromptFlow: vi.fn(),
@@ -52,6 +54,14 @@ const {
   mockSelectT3Components: vi.fn(),
   mockResolveConfig: vi.fn(),
   mockLoadPreset: vi.fn(),
+  mockBuildLock: vi.fn(),
+  mockWriteLockFile: vi.fn(),
+}))
+
+vi.mock('../../src/context/lock.js', () => ({
+  buildLock: mockBuildLock,
+  writeLockFile: mockWriteLockFile,
+  LOCK_FILENAME: 'tinkerise.lock',
 }))
 
 vi.mock('../../src/utils/banner.js', () => ({
@@ -131,6 +141,8 @@ describe('variant prompt wiring', () => {
     mockExecuteScaffolder.mockResolvedValue(undefined)
     mockBuildPreselectedOptions.mockReturnValue([])
     mockMergePromptAndFlags.mockReturnValue({})
+    mockBuildLock.mockReturnValue({ framework: 'next' })
+    mockWriteLockFile.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -217,6 +229,27 @@ describe('variant prompt wiring', () => {
       await runDirectExecution('web', 'next', 'my-app', cmd, {})
 
       expect(mockTinkeriseSummaryCard).toHaveBeenCalledWith('next', 'my-app', expect.any(Array))
+    })
+  })
+
+  describe('lock file', () => {
+    it('writes tinkerise.lock after a successful scaffold', async () => {
+      const cmd = createMockCommand()
+      await runDirectExecution('web', 'next', 'my-app', cmd, {})
+
+      expect(mockBuildLock).toHaveBeenCalledWith(
+        expect.objectContaining({ framework: 'next', packageManager: 'npm' }),
+      )
+      expect(mockWriteLockFile).toHaveBeenCalled()
+    })
+
+    it('completes the scaffold even if the lock write fails', async () => {
+      mockWriteLockFile.mockRejectedValueOnce(new Error('disk full'))
+
+      const cmd = createMockCommand()
+      await runDirectExecution('web', 'next', 'my-app', cmd, {})
+
+      expect(mockTinkeriseSummaryCard).toHaveBeenCalled()
     })
   })
 })

--- a/packages/cli/tests/commands/scaffold.test.ts
+++ b/packages/cli/tests/commands/scaffold.test.ts
@@ -95,6 +95,12 @@ vi.mock('@tinkerise/core', async (importOriginal) => {
   }
 })
 
+vi.mock('../../src/context/lock.js', () => ({
+  buildLock: vi.fn(() => ({})),
+  writeLockFile: vi.fn(),
+  LOCK_FILENAME: 'tinkerise.lock',
+}))
+
 vi.mock('../../src/prompts/variant-select.js', () => ({
   selectViteTemplate: mockSelectViteTemplate,
   resolveViteTemplate: mockResolveViteTemplate,

--- a/packages/cli/tests/context/lock.test.ts
+++ b/packages/cli/tests/context/lock.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for tinkerise.lock build + write.
+ *
+ * Verifies:
+ * - buildLock derives the category from the registry per framework
+ * - buildLock stamps schemaVersion/createdWith and defaults enhancements
+ * - buildLock throws on an unknown framework
+ * - writeLockFile emits a schema-valid file at tinkerise.lock
+ * - the lock is a committed artifact (never added to .gitignore)
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { LOCK_SCHEMA_VERSION, TinkeriseLockSchema, VERSION } from '@tinkerise/shared'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildLock, LOCK_FILENAME, writeLockFile } from '../../src/context/lock.js'
+
+describe('buildLock', () => {
+  it('derives the category from the registry per framework', () => {
+    expect(buildLock({ framework: 'next', flags: {}, packageManager: 'npm' }).category).toBe('web')
+    expect(buildLock({ framework: 'express', flags: {}, packageManager: 'npm' }).category).toBe('backend')
+    expect(buildLock({ framework: 'rn', flags: {}, packageManager: 'npm' }).category).toBe('mobile')
+  })
+
+  it('stamps schemaVersion and createdWith and defaults enhancements', () => {
+    const lock = buildLock({ framework: 'next', flags: { typescript: true }, packageManager: 'pnpm' })
+    expect(lock.schemaVersion).toBe(LOCK_SCHEMA_VERSION)
+    expect(lock.createdWith).toBe(VERSION)
+    expect(lock.enhancements).toEqual([])
+    expect(lock.flags).toEqual({ typescript: true })
+    expect(lock.packageManager).toBe('pnpm')
+  })
+
+  it('produces a schema-valid lock', () => {
+    const lock = buildLock({ framework: 'next', flags: { typescript: true }, packageManager: 'npm' })
+    expect(TinkeriseLockSchema.safeParse(lock).success).toBe(true)
+  })
+
+  it('throws on an unknown framework', () => {
+    expect(() => buildLock({ framework: 'nope', flags: {}, packageManager: 'npm' })).toThrow(/nope/)
+  })
+})
+
+describe('writeLockFile', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'tinkerise-lock-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('writes a schema-valid file at tinkerise.lock', async () => {
+    const lock = buildLock({ framework: 'next', flags: { typescript: true }, packageManager: 'bun' })
+    await writeLockFile(tempDir, lock)
+
+    const raw = await readFile(join(tempDir, LOCK_FILENAME), 'utf-8')
+    expect(LOCK_FILENAME).toBe('tinkerise.lock')
+    const parsed = TinkeriseLockSchema.safeParse(JSON.parse(raw))
+    expect(parsed.success).toBe(true)
+    expect(parsed.success && parsed.data).toEqual(lock)
+  })
+
+  it('does not add the lock to .gitignore (committed artifact)', async () => {
+    const lock = buildLock({ framework: 'next', flags: {}, packageManager: 'npm' })
+    await writeLockFile(tempDir, lock)
+
+    expect(existsSync(join(tempDir, '.gitignore'))).toBe(false)
+  })
+})

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,6 +32,20 @@ export type {
 } from './config/types.js'
 
 /**
+ * Lock — tinkerise.lock schema for reproducible projects (Tier B).
+ */
+export {
+  LOCK_SCHEMA_VERSION,
+  LockEnhancementSchema,
+  TinkeriseLockSchema,
+} from './lock/index.js'
+
+export type {
+  LockEnhancement,
+  TinkeriseLock,
+} from './lock/index.js'
+
+/**
  * JSON output — Zod 4 envelope and per-command schemas for `--json` mode (Phase 33).
  */
 export {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,20 +32,6 @@ export type {
 } from './config/types.js'
 
 /**
- * Lock — tinkerise.lock schema for reproducible projects (Tier B).
- */
-export {
-  LOCK_SCHEMA_VERSION,
-  LockEnhancementSchema,
-  TinkeriseLockSchema,
-} from './lock/index.js'
-
-export type {
-  LockEnhancement,
-  TinkeriseLock,
-} from './lock/index.js'
-
-/**
  * JSON output — Zod 4 envelope and per-command schemas for `--json` mode (Phase 33).
  */
 export {
@@ -85,6 +71,20 @@ export type {
   ScaffoldPlanEnvelopeV1,
   ScaffoldPlanPayloadV1,
 } from './json-output/index.js'
+
+/**
+ * Lock — tinkerise.lock schema for reproducible projects (Tier B).
+ */
+export {
+  LOCK_SCHEMA_VERSION,
+  LockEnhancementSchema,
+  TinkeriseLockSchema,
+} from './lock/index.js'
+
+export type {
+  LockEnhancement,
+  TinkeriseLock,
+} from './lock/index.js'
 
 /**
  * Registry — schemas, types, and helpers for the scaffolder registry.

--- a/packages/shared/src/lock/index.ts
+++ b/packages/shared/src/lock/index.ts
@@ -1,0 +1,1 @@
+export * from './schema.js'

--- a/packages/shared/src/lock/schema.ts
+++ b/packages/shared/src/lock/schema.ts
@@ -1,0 +1,30 @@
+/**
+ * tinkerise.lock — the reproducible record of a scaffolded project.
+ *
+ * Written after a scaffold (and enhancement) run; consumed by `scaffold --from-lock`
+ * and `tinkerise update`. The lock is a committed project artifact, not a cache.
+ */
+import { z } from 'zod'
+
+/** Lock schema version. Bump on any breaking shape change. */
+export const LOCK_SCHEMA_VERSION = 1
+
+/** A single enhancement recorded in the lock; version is null when unknown. */
+export const LockEnhancementSchema = z.object({
+  id: z.string(),
+  version: z.string().nullable(),
+})
+
+export const TinkeriseLockSchema = z.object({
+  schemaVersion: z.literal(LOCK_SCHEMA_VERSION),
+  framework: z.string(),
+  category: z.enum(['web', 'backend', 'mobile', 'utility']),
+  flags: z.record(z.string(), z.union([z.string(), z.boolean()])),
+  enhancements: z.array(LockEnhancementSchema),
+  packageManager: z.string(),
+  /** tinkerise version that produced this lock */
+  createdWith: z.string(),
+})
+
+export type LockEnhancement = z.infer<typeof LockEnhancementSchema>
+export type TinkeriseLock = z.infer<typeof TinkeriseLockSchema>

--- a/packages/shared/tests/lock/schema.test.ts
+++ b/packages/shared/tests/lock/schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { LOCK_SCHEMA_VERSION, TinkeriseLockSchema } from '../../src/lock/schema.js'
+
+const validLock = {
+  schemaVersion: LOCK_SCHEMA_VERSION,
+  framework: 'next',
+  category: 'web',
+  flags: { typescript: true, template: 'react-ts' },
+  enhancements: [{ id: 'eslint', version: '9.0.0' }, { id: 'prettier', version: null }],
+  packageManager: 'pnpm',
+  createdWith: '0.2.4',
+}
+
+describe('tinkeriseLockSchema', () => {
+  it('accepts a complete valid lock', () => {
+    const parsed = TinkeriseLockSchema.safeParse(validLock)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts an empty enhancements list', () => {
+    const parsed = TinkeriseLockSchema.safeParse({ ...validLock, enhancements: [] })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects an unknown category', () => {
+    const parsed = TinkeriseLockSchema.safeParse({ ...validLock, category: 'desktop' })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects a mismatched schemaVersion', () => {
+    const parsed = TinkeriseLockSchema.safeParse({ ...validLock, schemaVersion: 2 })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects a missing required field', () => {
+    const { packageManager: _omitted, ...withoutPm } = validLock
+    const parsed = TinkeriseLockSchema.safeParse(withoutPm)
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects an enhancement missing its id', () => {
+    const parsed = TinkeriseLockSchema.safeParse({
+      ...validLock,
+      enhancements: [{ version: '1.0.0' }],
+    })
+    expect(parsed.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Tier B — Statefulness (foundation): record a reproducible `tinkerise.lock`

First step of the [competitive-improvements](docs/improvements) Tier B program. Every successful scaffold now writes a committed, schema-validated `tinkerise.lock` capturing exactly what was generated — the reproducible twin of the `--dry-run` plan, and the unit later tiers distribute.

### What it does
- **`@tinkerise/shared`** — new `TinkeriseLockSchema` (Zod 4): `{ schemaVersion, framework, category, flags, enhancements, packageManager, createdWith }`.
- **`@tinkerise/cli`** — `buildLock()` (derives `category` from the registry so callers pass only the framework) + `writeLockFile()`.
- Wired into the scaffold pipeline right after the session write. **Best-effort**: a lock-write failure warns but never fails an already-successful scaffold.

### Boundaries (deliberate)
- The lock is a **committed artifact** (like `package-lock.json`) — it is *not* added to `.gitignore` (contrast with the session file).
- `enhancements` is recorded as `[]` at scaffold time; populating it (and the consumers `scaffold --from-lock` / `tinkerise update`) are follow-up PRs.

### Tests (TDD)
- shared: schema accept/reject cases (category, schemaVersion, required fields, enhancement shape).
- cli: `buildLock` category derivation (next→web, express→backend, rn→mobile), version/defaults stamping, unknown-framework guard; `writeLockFile` round-trips a schema-valid file and never touches `.gitignore`.
- cli wiring: lock is written after a successful scaffold; scaffold still completes if the lock write throws.

Full gate green locally: lint, typecheck, test (85 + 665 + 454), build. Changeset included (`@tinkerise/cli` + `@tinkerise/shared` minor).
