### PR TITLE
feat(cli): record applied enhancements in tinkerise.lock

### DIFF
--- a/.changeset/lock-record-enhancements.md
+++ b/.changeset/lock-record-enhancements.md
@@ -1,0 +1,5 @@
+---
+"@tinkerise/cli": minor
+---
+
+`tinkerise add` now records applied enhancements into `tinkerise.lock`, keeping the lock an accurate, reproducible record of a project's stack. Best-effort: a lock update never fails an otherwise-successful `add`, and projects without a lock are left untouched.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -22,6 +22,7 @@ import {
   TinkeriseError,
   UnknownEnhancementError,
 } from '@tinkerise/core'
+import { recordEnhancements } from '../context/lock.js'
 import { getSessionContext } from '../context/session.js'
 import { showEnhancementPicker } from '../prompts/enhancement-select.js'
 
@@ -40,10 +41,11 @@ export async function runAddCommand(
   options: AddOptions,
 ): Promise<void> {
   const session = await getSessionContext()
+  const rootDir = session.projectDir ?? process.cwd()
 
   // 1. Build project context
   const ctx = await buildProjectContext({
-    rootDir: session.projectDir ?? process.cwd(),
+    rootDir,
     packageManager: session.packageManager,
     framework: session.framework,
     freshScaffold: !!session.projectDir,
@@ -149,4 +151,13 @@ export async function runAddCommand(
 
   // 5. Show overall summary
   showEnhancementSummary(summary)
+
+  // 6. Keep the lock's enhancement list in sync (best-effort, provenance only).
+  try {
+    await recordEnhancements(rootDir, summary.installed)
+  }
+  catch {
+    // A stale lock must not fail an otherwise-successful add.
+    p.log.warn('Could not update tinkerise.lock with the new enhancements')
+  }
 }

--- a/packages/cli/src/context/lock.ts
+++ b/packages/cli/src/context/lock.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TinkeriseLock } from '@tinkerise/shared'
-import { writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getScaffolder } from '@tinkerise/core'
 import { LOCK_SCHEMA_VERSION, TinkeriseLockSchema, VERSION } from '@tinkerise/shared'
@@ -47,4 +47,36 @@ export async function writeLockFile(projectDir: string, lock: TinkeriseLock): Pr
     `${JSON.stringify(lock, null, 2)}\n`,
     'utf-8',
   )
+}
+
+/** Read and validate the lock from a project directory; null if missing or invalid. */
+export async function readLockFile(projectDir: string): Promise<TinkeriseLock | null> {
+  try {
+    const raw = await readFile(join(projectDir, LOCK_FILENAME), 'utf-8')
+    const parsed = TinkeriseLockSchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : null
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Record applied enhancements in the existing lock (deduped, version unknown).
+ * No-op when the project has no lock — there is nothing to keep reproducible.
+ */
+export async function recordEnhancements(projectDir: string, ids: string[]): Promise<void> {
+  if (ids.length === 0)
+    return
+
+  const lock = await readLockFile(projectDir)
+  if (!lock)
+    return
+
+  const known = new Set(lock.enhancements.map(e => e.id))
+  const added = ids.filter(id => !known.has(id)).map(id => ({ id, version: null }))
+  if (added.length === 0)
+    return
+
+  await writeLockFile(projectDir, { ...lock, enhancements: [...lock.enhancements, ...added] })
 }

--- a/packages/cli/tests/commands/add.test.ts
+++ b/packages/cli/tests/commands/add.test.ts
@@ -28,6 +28,8 @@ const mockGetSessionContext = vi.hoisted(() => vi.fn())
 const mockProcessExit = vi.hoisted(() => vi.fn())
 const mockPLogError = vi.hoisted(() => vi.fn())
 const mockPLogInfo = vi.hoisted(() => vi.fn())
+const mockPLogWarn = vi.hoisted(() => vi.fn())
+const mockRecordEnhancements = vi.hoisted(() => vi.fn())
 
 vi.mock('@tinkerise/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tinkerise/core')>()
@@ -45,7 +47,7 @@ vi.mock('@tinkerise/core', async (importOriginal) => {
 })
 
 vi.mock('@clack/prompts', () => ({
-  log: { error: mockPLogError, info: mockPLogInfo },
+  log: { error: mockPLogError, info: mockPLogInfo, warn: mockPLogWarn },
   select: vi.fn(),
   confirm: vi.fn(),
   cancel: vi.fn(),
@@ -54,6 +56,10 @@ vi.mock('@clack/prompts', () => ({
 
 vi.mock('../../src/context/session.js', () => ({
   getSessionContext: mockGetSessionContext,
+}))
+
+vi.mock('../../src/context/lock.js', () => ({
+  recordEnhancements: mockRecordEnhancements,
 }))
 
 vi.mock('../../src/prompts/enhancement-select.js', () => ({
@@ -199,6 +205,33 @@ describe('runAddCommand', () => {
     await expect(
       runAddCommand([], {}),
     ).rejects.toThrow('No enhancements specified')
+  })
+
+  it('records installed enhancements in the lock', async () => {
+    mockRunEnhancements.mockResolvedValue({
+      installed: ['eslint', 'prettier'],
+      skipped: [],
+      failed: [],
+      notRun: [],
+      results: new Map(),
+    })
+
+    await runAddCommand(['eslint', 'prettier'], {})
+
+    expect(mockRecordEnhancements).toHaveBeenCalledWith(expect.any(String), ['eslint', 'prettier'])
+  })
+
+  it('does not fail the command when recording the lock throws', async () => {
+    mockRecordEnhancements.mockRejectedValueOnce(new Error('disk full'))
+    mockRunEnhancements.mockResolvedValue({
+      installed: ['eslint'],
+      skipped: [],
+      failed: [],
+      notRun: [],
+      results: new Map(),
+    })
+
+    await expect(runAddCommand(['eslint'], {})).resolves.toBeUndefined()
   })
 
   it('passes verbose option to buildProjectContext', async () => {

--- a/packages/cli/tests/context/lock.test.ts
+++ b/packages/cli/tests/context/lock.test.ts
@@ -10,12 +10,12 @@
  */
 
 import { existsSync } from 'node:fs'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { LOCK_SCHEMA_VERSION, TinkeriseLockSchema, VERSION } from '@tinkerise/shared'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { buildLock, LOCK_FILENAME, writeLockFile } from '../../src/context/lock.js'
+import { buildLock, LOCK_FILENAME, readLockFile, recordEnhancements, writeLockFile } from '../../src/context/lock.js'
 
 describe('buildLock', () => {
   it('derives the category from the registry per framework', () => {
@@ -70,5 +70,77 @@ describe('writeLockFile', () => {
     await writeLockFile(tempDir, lock)
 
     expect(existsSync(join(tempDir, '.gitignore'))).toBe(false)
+  })
+})
+
+describe('readLockFile', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'tinkerise-lock-read-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns the parsed lock when present and valid', async () => {
+    const lock = buildLock({ framework: 'next', flags: { typescript: true }, packageManager: 'pnpm' })
+    await writeLockFile(tempDir, lock)
+
+    expect(await readLockFile(tempDir)).toEqual(lock)
+  })
+
+  it('returns null when the file is missing', async () => {
+    expect(await readLockFile(tempDir)).toBeNull()
+  })
+
+  it('returns null for invalid JSON', async () => {
+    await writeFile(join(tempDir, LOCK_FILENAME), 'not json', 'utf-8')
+    expect(await readLockFile(tempDir)).toBeNull()
+  })
+
+  it('returns null when content fails schema validation', async () => {
+    await writeFile(join(tempDir, LOCK_FILENAME), JSON.stringify({ schemaVersion: 1 }), 'utf-8')
+    expect(await readLockFile(tempDir)).toBeNull()
+  })
+})
+
+describe('recordEnhancements', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'tinkerise-lock-enh-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('appends new enhancements with a null version', async () => {
+    await writeLockFile(tempDir, buildLock({ framework: 'next', flags: {}, packageManager: 'npm' }))
+
+    await recordEnhancements(tempDir, ['eslint', 'prettier'])
+
+    const lock = await readLockFile(tempDir)
+    expect(lock?.enhancements).toEqual([
+      { id: 'eslint', version: null },
+      { id: 'prettier', version: null },
+    ])
+  })
+
+  it('does not duplicate enhancements already recorded', async () => {
+    await writeLockFile(tempDir, buildLock({ framework: 'next', flags: {}, packageManager: 'npm' }))
+
+    await recordEnhancements(tempDir, ['eslint'])
+    await recordEnhancements(tempDir, ['eslint', 'husky'])
+
+    const lock = await readLockFile(tempDir)
+    expect(lock?.enhancements.map(e => e.id)).toEqual(['eslint', 'husky'])
+  })
+
+  it('is a no-op when no lock file exists', async () => {
+    await recordEnhancements(tempDir, ['eslint'])
+    expect(existsSync(join(tempDir, LOCK_FILENAME))).toBe(false)
   })
 })


### PR DESCRIPTION
## Tier B — record applied enhancements into `tinkerise.lock`

Follow-up to #44. After a scaffold, the lock recorded `enhancements: []`; it stayed empty even after `tinkerise add eslint`. This makes the lock an accurate record of a project's full stack — and lays the groundwork for a future re-apply command.

### What it does
- **`readLockFile(dir)`** — reads + schema-validates `tinkerise.lock`; returns `null` for missing / invalid-JSON / schema-invalid files.
- **`recordEnhancements(dir, ids)`** — merges newly-applied enhancement ids into the lock's `enhancements` (deduped, `version: null` for now). No-op when the project has no lock.
- Wired into `tinkerise add` (step 6), recording `summary.installed` (only enhancements that actually applied). **Best-effort**: a lock-update failure warns but never fails a successful `add`; non-tinkerise projects are left untouched.

### Notes / boundaries
- `version` is recorded as `null` — the registry doesn't expose per-enhancement versions yet (a roadmap open question). The id is what a future re-apply needs; versions (for staleness) can be populated later without a schema change.
- CLI-only; reuses the `tinkerise.lock` schema from #44.

### Tests (TDD)
- `readLockFile`: valid round-trip, missing → null, invalid JSON → null, schema-invalid → null.
- `recordEnhancements`: appends with null version, dedups across repeated calls, no-op without a lock.
- `add` wiring: records `summary.installed`; a recording failure doesn't fail the command.

Full gate green locally: lint, typecheck, test (85 + 665 + 463), build. Changeset included (`@tinkerise/cli` minor).
