### PR TITLE
feat(cli): add --from-lock to re-apply recorded enhancements

### DIFF
--- a/.changeset/add-from-lock.md
+++ b/.changeset/add-from-lock.md
@@ -1,0 +1,5 @@
+---
+"@tinkerise/cli": minor
+---
+
+Add `tinkerise add --from-lock`: re-apply the enhancements recorded in `tinkerise.lock` through the normal `add` pipeline (conflict-aware). Errors clearly when no lock is present, and reports when the lock records no enhancements. Lock ids are merged with any explicitly-passed enhancement names.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -22,12 +22,14 @@ import {
   TinkeriseError,
   UnknownEnhancementError,
 } from '@tinkerise/core'
-import { recordEnhancements } from '../context/lock.js'
+import { readLockFile, recordEnhancements } from '../context/lock.js'
 import { getSessionContext } from '../context/session.js'
 import { showEnhancementPicker } from '../prompts/enhancement-select.js'
 
 export interface AddOptions {
   verbose?: boolean
+  /** Re-apply the enhancements recorded in tinkerise.lock */
+  fromLock?: boolean
 }
 
 /**
@@ -42,6 +44,24 @@ export async function runAddCommand(
 ): Promise<void> {
   const session = await getSessionContext()
   const rootDir = session.projectDir ?? process.cwd()
+
+  // 0. --from-lock: source enhancement ids from tinkerise.lock (re-apply).
+  let names = enhancementNames
+  if (options.fromLock) {
+    const lock = await readLockFile(rootDir)
+    if (!lock) {
+      throw new TinkeriseError({
+        message: 'No tinkerise.lock found in this directory.',
+        code: 'LOCK_NOT_FOUND',
+        suggestion: 'Run tinkerise add <enhancements> to set up tooling first.',
+      })
+    }
+    names = [...new Set([...lock.enhancements.map(e => e.id), ...enhancementNames])]
+    if (names.length === 0) {
+      p.log.info('No enhancements recorded in tinkerise.lock — nothing to re-apply.')
+      return
+    }
+  }
 
   // 1. Build project context
   const ctx = await buildProjectContext({
@@ -68,7 +88,7 @@ export async function runAddCommand(
   // 2. Determine which enhancements to run
   let modules: EnhancementModule[]
 
-  if (enhancementNames.length === 0) {
+  if (names.length === 0) {
     // Interactive: show multi-select picker
     if (isCI) {
       throw new TinkeriseError({
@@ -83,7 +103,7 @@ export async function runAddCommand(
   }
   else {
     // Direct: resolve names to modules
-    modules = enhancementNames.map((name) => {
+    modules = names.map((name) => {
       const mod = enhancementRegistry.get(name)
       if (!mod) {
         throw new UnknownEnhancementError(name, allEnhancementModules.map(m => m.id))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -164,6 +164,7 @@ program
   .description('Add ESLint, Prettier, husky, GitHub Actions CI, Docker, env, commitlint, testing, Renovate, EditorConfig, and more to your project. Run without arguments for an interactive picker.')
   .argument('[enhancements...]', 'Enhancement names (eslint, prettier, husky, ci, docker, env, commitlint, testing, renovate, editorconfig)')
   .option('--verbose', 'Show detailed output from package installation')
+  .option('--from-lock', 'Re-apply the enhancements recorded in tinkerise.lock')
   .action(async (enhancements: string[], options) => {
     await runAddCommand(enhancements, options)
   })
@@ -171,7 +172,8 @@ program
 Examples:
   $ ${programName} add eslint                 Add ESLint to your project
   $ ${programName} add eslint prettier husky  Add multiple enhancements
-  $ ${programName} add                        Interactive enhancement picker`)
+  $ ${programName} add                        Interactive enhancement picker
+  $ ${programName} add --from-lock            Re-apply enhancements from tinkerise.lock`)
 
 // Doctor command — check system for required tools and versions
 program

--- a/packages/cli/tests/commands/add.test.ts
+++ b/packages/cli/tests/commands/add.test.ts
@@ -30,6 +30,7 @@ const mockPLogError = vi.hoisted(() => vi.fn())
 const mockPLogInfo = vi.hoisted(() => vi.fn())
 const mockPLogWarn = vi.hoisted(() => vi.fn())
 const mockRecordEnhancements = vi.hoisted(() => vi.fn())
+const mockReadLockFile = vi.hoisted(() => vi.fn())
 
 vi.mock('@tinkerise/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tinkerise/core')>()
@@ -60,6 +61,7 @@ vi.mock('../../src/context/session.js', () => ({
 
 vi.mock('../../src/context/lock.js', () => ({
   recordEnhancements: mockRecordEnhancements,
+  readLockFile: mockReadLockFile,
 }))
 
 vi.mock('../../src/prompts/enhancement-select.js', () => ({
@@ -232,6 +234,47 @@ describe('runAddCommand', () => {
     })
 
     await expect(runAddCommand(['eslint'], {})).resolves.toBeUndefined()
+  })
+
+  it('re-applies enhancements recorded in the lock with --from-lock', async () => {
+    mockReadLockFile.mockResolvedValue({
+      enhancements: [{ id: 'eslint', version: null }, { id: 'prettier', version: null }],
+    })
+    mockRunEnhancements.mockResolvedValue({
+      installed: ['eslint', 'prettier'],
+      skipped: [],
+      failed: [],
+      notRun: [],
+      results: new Map(),
+    })
+
+    await runAddCommand([], { fromLock: true })
+
+    expect(mockShowEnhancementPicker).not.toHaveBeenCalled()
+    expect(mockRunEnhancements).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modules: expect.arrayContaining([
+          expect.objectContaining({ id: 'eslint' }),
+          expect.objectContaining({ id: 'prettier' }),
+        ]),
+      }),
+    )
+  })
+
+  it('reports nothing to re-apply when the lock has no enhancements', async () => {
+    mockReadLockFile.mockResolvedValue({ enhancements: [] })
+
+    await runAddCommand([], { fromLock: true })
+
+    expect(mockRunEnhancements).not.toHaveBeenCalled()
+    expect(mockPLogInfo).toHaveBeenCalled()
+  })
+
+  it('throws when --from-lock is used without a lock file', async () => {
+    mockReadLockFile.mockResolvedValue(null)
+
+    await expect(runAddCommand([], { fromLock: true })).rejects.toThrow(/tinkerise\.lock/i)
+    expect(mockRunEnhancements).not.toHaveBeenCalled()
   })
 
   it('passes verbose option to buildProjectContext', async () => {


### PR DESCRIPTION
## Tier B — `tinkerise add --from-lock` (re-apply recorded enhancements)

Completes the read side of Tier B statefulness. After #44 (write lock) and #45 (record enhancements), this re-applies a project's recorded tooling through the existing `add` pipeline.

> The roadmap calls this `tinkerise update`, but that name is already taken by the self-update command — so this ships as a flag on `add`, keeping the `--from-lock` name consistent for a future `scaffold --from-lock`.

### What it does
- `tinkerise add --from-lock` reads `tinkerise.lock`, takes its recorded enhancement ids, and runs them through the normal conflict-aware `add` flow (`detect → install`, with skip/replace/merge on existing config).
- Merges lock ids with any explicit positional names (deduped), so `add --from-lock prettier` re-applies the lock set plus prettier.
- Clear UX: errors (`LOCK_NOT_FOUND`) when no lock exists; logs "nothing to re-apply" when the lock records no enhancements.

### Why a flag on `add` (not a new command)
Re-applying enhancements *is* `add` with a different source — reusing `runAddCommand` keeps it DRY (conflict handling, summaries, lock re-recording all come for free) and avoids inventing a command name that collides with `update`.

### Tests (TDD)
- re-applies the lock's enhancements (picker skipped, modules resolved);
- reports + returns when the lock has no enhancements;
- throws when `--from-lock` is used with no lock present.
- Verified end-to-end with the built CLI: `add --from-lock` in a lock-less dir exits 1 with the `LOCK_NOT_FOUND` message.

Full gate green locally: lint, typecheck, test (466 CLI), build. Changeset included (`@tinkerise/cli` minor).
