### PR TITLE
feat(cli): scaffold --from-lock to reproduce a project from tinkerise.lock

### DIFF
--- a/.changeset/scaffold-from-lock.md
+++ b/.changeset/scaffold-from-lock.md
@@ -1,0 +1,5 @@
+---
+"@tinkerise/cli": minor
+---
+
+Add `tinkerise <name> --from-lock`: reproduce a project non-interactively from a `tinkerise.lock`, replaying the recorded framework, flags, and package manager. Works for all frameworks except those with interactive variant selection (Vite, T3), which surface a clear, actionable error since their variants aren't captured in the lock yet.

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -17,9 +17,9 @@ import type { PresetData, ScaffolderCategory, TinkeriseUserConfig } from '@tinke
 import type { Command } from 'commander'
 import { join } from 'node:path'
 import * as p from '@clack/prompts'
-import { ConfigValidationError, detectPackageManager, executeScaffolder, findClosestMatch, InteractivePromptBlockedError, InvalidCategoryError, isCI, loadPreset, resolveConfig, tinkeriseSummaryCard } from '@tinkerise/core'
+import { ConfigValidationError, detectPackageManager, executeScaffolder, findClosestMatch, InteractivePromptBlockedError, InvalidCategoryError, isCI, loadPreset, resolveConfig, TinkeriseError, tinkeriseSummaryCard } from '@tinkerise/core'
 import pc from 'picocolors'
-import { buildLock, LOCK_FILENAME, writeLockFile } from '../context/lock.js'
+import { buildLock, LOCK_FILENAME, readLockFile, writeLockFile } from '../context/lock.js'
 import { setSessionContext, writeSessionFile } from '../context/session.js'
 import { runPromptFlow } from '../prompts/flow.js'
 import { promptPackageManager } from '../prompts/pm-select.js'
@@ -252,6 +252,21 @@ async function executePipeline(
   config?: Partial<TinkeriseUserConfig>,
 ): Promise<void> {
   const userFlags = buildUserFlags(options, cmd, cliOptions, pm, config)
+  await runResolvedScaffold(framework, name, userFlags, cliOptions, pm)
+}
+
+/**
+ * Execute a scaffold from fully-resolved userFlags: handle framework variants,
+ * spawn the upstream tool, then persist session + lock. Shared by the prompt
+ * pipeline and `--from-lock` reproduction.
+ */
+async function runResolvedScaffold(
+  framework: string,
+  name: string,
+  userFlags: Record<string, string | boolean>,
+  cliOptions: ScaffoldOptions,
+  pm: PackageManager,
+): Promise<void> {
   const dryRun = isDryRun(cliOptions)
 
   // vite/t3 prompt for a variant; in --json dry-run that would corrupt output (D-14)
@@ -457,4 +472,53 @@ export async function runDirectExecution(
   // If we have preselected options, use them directly; otherwise use empty array
   // (direct execution skips the options multiselect)
   await executePipeline(framework, projectName, preselected, cmd, options, pm, config)
+}
+
+/**
+ * Frameworks whose interactive variant selection (Vite template, T3 components)
+ * is not captured in the lock, so `--from-lock` cannot reproduce them yet.
+ */
+const FROM_LOCK_UNSUPPORTED = new Set(['vite', 't3'])
+
+/**
+ * Reproduce a project from a `tinkerise.lock` in the current directory.
+ *
+ * Non-interactive: the locked framework + flags drive the same execution path
+ * as a normal scaffold. The new project name is supplied by the caller.
+ */
+export async function runFromLock(
+  name: string | undefined,
+  options: ScaffoldOptions,
+): Promise<void> {
+  if (!name) {
+    throw new TinkeriseError({
+      message: 'A project name is required with --from-lock.',
+      code: 'MISSING_PROJECT_NAME',
+      suggestion: 'Example: tinkerise my-app --from-lock',
+    })
+  }
+
+  const lock = await readLockFile(process.cwd())
+  if (!lock) {
+    throw new TinkeriseError({
+      message: 'No tinkerise.lock found in this directory.',
+      code: 'LOCK_NOT_FOUND',
+      suggestion: 'Run --from-lock from a directory containing a tinkerise.lock.',
+    })
+  }
+
+  if (FROM_LOCK_UNSUPPORTED.has(lock.framework)) {
+    throw new TinkeriseError({
+      message: `--from-lock does not support ${lock.framework} yet (its variant selection is not captured in the lock).`,
+      code: 'LOCK_UNSUPPORTED_FRAMEWORK',
+      suggestion: `Scaffold it directly, e.g. tinkerise ${lock.category} ${lock.framework} ${name}`,
+    })
+  }
+
+  const projectNameError = validateProjectName(name)
+  if (projectNameError) {
+    throw new ConfigValidationError('projectName', name, 'lowercase letters, numbers, hyphens, dots, underscores; max 64 chars')
+  }
+
+  await runResolvedScaffold(lock.framework, name, { ...lock.flags }, options, lock.packageManager as PackageManager)
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,7 +23,7 @@ import { registerLibCommand } from './commands/lib.js'
 import { listScaffolders } from './commands/list.js'
 import { registerMcpCommand } from './commands/mcp.js'
 import { registerPresetCommand } from './commands/preset.js'
-import { runCategoryFlow, runDirectExecution, runInteractiveFlow } from './commands/scaffold.js'
+import { runCategoryFlow, runDirectExecution, runFromLock, runInteractiveFlow } from './commands/scaffold.js'
 import { registerUpdateCommand } from './commands/update.js'
 import { handleError } from './utils/error-handler.js'
 import { detectJsonMode, isJsonMode } from './utils/output-mode.js'
@@ -89,6 +89,7 @@ program
   .option('--json', 'Emit machine-readable JSON output (list, doctor, preset list/show, dry-run)')
   .option('--dry-run', 'Show the command that would run without executing')
   .option('--explain', 'Like --dry-run, plus flag and prerequisite details (implies --dry-run)')
+  .option('--from-lock', 'Reproduce a project from a tinkerise.lock (the first argument is the new project name)')
 
 const VALID_CATEGORIES = ['web', 'backend', 'mobile']
 
@@ -102,6 +103,12 @@ program
     // Merge --ts alias into --typescript
     if (options.ts) {
       options.typescript = true
+    }
+
+    // --from-lock: reproduce from tinkerise.lock; the first positional is the new name.
+    if (options.fromLock) {
+      await runFromLock(category, options)
+      return
     }
 
     // Existing positional contract: first arg is a known category.
@@ -221,6 +228,7 @@ Examples:
   $ ${programName} web next my-app            Create a Next.js project
   $ ${programName} web vite my-app --ts       Create with TypeScript
   $ ${programName} my-app next ts tailwind    Natural-language stack tokens
+  $ ${programName} my-app --from-lock         Reproduce a project from tinkerise.lock
   $ ${programName} monorepo my-repo           Create a Turborepo monorepo
   $ ${programName} list                       Show available scaffolders
   $ ${programName} list web                   Show web scaffolders with details

--- a/packages/cli/tests/commands/scaffold-wiring.test.ts
+++ b/packages/cli/tests/commands/scaffold-wiring.test.ts
@@ -13,7 +13,7 @@
 import type { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { runDirectExecution } from '../../src/commands/scaffold.js'
+import { runDirectExecution, runFromLock } from '../../src/commands/scaffold.js'
 
 // vi.hoisted for mock fns used in vi.mock factories
 const {
@@ -36,6 +36,7 @@ const {
   mockLoadPreset,
   mockBuildLock,
   mockWriteLockFile,
+  mockReadLockFile,
 } = vi.hoisted(() => ({
   mockShowBanner: vi.fn(),
   mockRunPromptFlow: vi.fn(),
@@ -56,11 +57,13 @@ const {
   mockLoadPreset: vi.fn(),
   mockBuildLock: vi.fn(),
   mockWriteLockFile: vi.fn(),
+  mockReadLockFile: vi.fn(),
 }))
 
 vi.mock('../../src/context/lock.js', () => ({
   buildLock: mockBuildLock,
   writeLockFile: mockWriteLockFile,
+  readLockFile: mockReadLockFile,
   LOCK_FILENAME: 'tinkerise.lock',
 }))
 
@@ -87,6 +90,11 @@ vi.mock('@tinkerise/core', () => ({
   tinkeriseSummaryCard: mockTinkeriseSummaryCard,
   resolveConfig: mockResolveConfig,
   loadPreset: mockLoadPreset,
+  TinkeriseError: class TinkeriseError extends Error {
+    constructor(opts: { message: string }) {
+      super(opts.message)
+    }
+  },
   get isCI() { return mockIsCI.value },
 }))
 
@@ -250,6 +258,52 @@ describe('variant prompt wiring', () => {
       await runDirectExecution('web', 'next', 'my-app', cmd, {})
 
       expect(mockTinkeriseSummaryCard).toHaveBeenCalled()
+    })
+  })
+
+  describe('from-lock reproduction', () => {
+    function lockFor(framework: string, flags: Record<string, string | boolean> = {}) {
+      return {
+        schemaVersion: 1,
+        framework,
+        category: 'web',
+        flags,
+        enhancements: [],
+        packageManager: 'npm',
+        createdWith: '0.0.0',
+      }
+    }
+
+    it('reproduces a project from the lock flags', async () => {
+      mockReadLockFile.mockResolvedValue(lockFor('next', { typescript: true, tailwind: true }))
+
+      await runFromLock('reproduced-app', {})
+
+      expect(mockExecuteScaffolder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scaffolderName: 'next',
+          projectName: 'reproduced-app',
+          userFlags: { typescript: true, tailwind: true },
+        }),
+      )
+    })
+
+    it('throws when no lock is present', async () => {
+      mockReadLockFile.mockResolvedValue(null)
+
+      await expect(runFromLock('app', {})).rejects.toThrow(/tinkerise\.lock/i)
+      expect(mockExecuteScaffolder).not.toHaveBeenCalled()
+    })
+
+    it('throws for frameworks whose variants the lock cannot capture', async () => {
+      mockReadLockFile.mockResolvedValue(lockFor('vite'))
+
+      await expect(runFromLock('app', {})).rejects.toThrow(/vite/i)
+      expect(mockExecuteScaffolder).not.toHaveBeenCalled()
+    })
+
+    it('throws when no project name is provided', async () => {
+      await expect(runFromLock(undefined, {})).rejects.toThrow(/name/i)
     })
   })
 })


### PR DESCRIPTION
## Tier B capstone — `tinkerise <name> --from-lock`

Reproduce a project non-interactively from a `tinkerise.lock`, replaying the recorded framework, flags, and package manager. This completes Tier B's "reproducible projects" goal (after write #44, record #45, re-apply #46).

```
tinkerise my-new-app --from-lock      # reads ./tinkerise.lock, scaffolds my-new-app with the same stack
```

### What it does
- Reads `./tinkerise.lock`, then drives the **same execution path** as a normal scaffold using the locked framework + flags (so the reproduced project also gets its own fresh lock + session).
- The new project name is the first positional; the lock supplies everything else.

### Design
- **DRY via extraction**: the tail of `executePipeline` (variant handling → spawn → session/lock persistence) is factored into a shared `runResolvedScaffold(framework, name, userFlags, …)`. Both the prompt pipeline and `--from-lock` call it, so there is no second execution path to drift — and no fragile inverse flag-mapping. The extraction is behavior-preserving (covered by the existing scaffold suite).
- **Honest boundary**: Vite and T3 select variants interactively (template / components) that the lock does not capture yet, so `--from-lock` rejects them with an actionable error instead of producing a wrong project. Capturing those variants is a follow-up.

### Errors (all tested + smoke-verified on the built CLI)
- no name → `MISSING_PROJECT_NAME`
- no lock in cwd → `LOCK_NOT_FOUND`
- vite/t3 lock → `LOCK_UNSUPPORTED_FRAMEWORK` (suggests scaffolding directly)
- happy path (`--from-lock --dry-run` with a Next lock) → `npx create-next-app reproduced-app --ts --tailwind --yes`

### Tests (TDD)
- reproduces from lock flags (asserts `executeScaffolder` args);
- throws on missing lock / unsupported framework / missing name;
- existing scaffold suite proves the `runResolvedScaffold` extraction is behavior-preserving.

Full gate green locally: lint, typecheck, test (470 CLI), build. Changeset included (`@tinkerise/cli` minor).
