### PR TITLE
feat: capture and reproduce framework variants via tinkerise.lock

### DIFF
--- a/.changeset/lock-variant-capture.md
+++ b/.changeset/lock-variant-capture.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/shared": minor
+---
+
+Capture framework variant selections (Vite template + TypeScript, T3 components) in `tinkerise.lock` via a new optional `variant` field, and reproduce them with `--from-lock`. Vite and T3 are now fully supported by `tinkerise <name> --from-lock`; locks written before this change surface a clear `LOCK_MISSING_VARIANT` error for those two frameworks.

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -13,7 +13,7 @@
  */
 
 import type { PackageManager } from '@tinkerise/core'
-import type { PresetData, ScaffolderCategory, TinkeriseUserConfig } from '@tinkerise/shared'
+import type { LockVariant, PresetData, ScaffolderCategory, TinkeriseUserConfig } from '@tinkerise/shared'
 import type { Command } from 'commander'
 import { join } from 'node:path'
 import * as p from '@clack/prompts'
@@ -266,23 +266,30 @@ async function runResolvedScaffold(
   userFlags: Record<string, string | boolean>,
   cliOptions: ScaffoldOptions,
   pm: PackageManager,
+  replayVariant?: LockVariant,
 ): Promise<void> {
   const dryRun = isDryRun(cliOptions)
 
-  // vite/t3 prompt for a variant; in --json dry-run that would corrupt output (D-14)
-  if (framework === 't3' || (framework === 'vite' && !cliOptions.template))
+  // A variant prompt only fires when there is no replay variant to reuse; in
+  // --json dry-run that prompt would corrupt output (D-14).
+  const willPromptVariant = !replayVariant && (framework === 't3' || (framework === 'vite' && !cliOptions.template))
+  if (willPromptVariant)
     assertJsonNonInteractive(dryRun)
 
   let extraArgs: string[] = []
+  // Variant selections captured for the lock so --from-lock can reproduce them.
+  let variant: LockVariant | undefined
 
   if (framework === 'vite') {
     // Vite: template selection + TypeScript merging
-    const base = await selectViteTemplate(cliOptions.template)
-    const resolved = resolveViteTemplate(base, !!cliOptions.typescript)
+    const base = replayVariant?.template ?? await selectViteTemplate(cliOptions.template)
+    const typescript = replayVariant?.typescript ?? Boolean(cliOptions.typescript)
+    const resolved = resolveViteTemplate(base, typescript)
     extraArgs = ['--template', resolved]
     // Remove typescript and template from userFlags -- handled via template suffix / extraArgs
     delete userFlags.typescript
     delete userFlags.template
+    variant = { template: base, typescript }
   }
 
   // Suppress interactive prompts for frameworks that support it
@@ -295,7 +302,7 @@ async function runResolvedScaffold(
 
   if (framework === 't3') {
     // T3: component selection -> pass as individual flags
-    const components = await selectT3Components()
+    const components = replayVariant?.components ?? await selectT3Components()
     for (const comp of components) {
       extraArgs.push(`--${comp}`)
     }
@@ -303,6 +310,7 @@ async function runResolvedScaffold(
     if (extraArgs.length > 0 || Object.keys(userFlags).length > 0) {
       extraArgs.push('--CI')
     }
+    variant = { components }
   }
 
   const plan = await executeScaffolder({
@@ -326,7 +334,7 @@ async function runResolvedScaffold(
   // Persist the reproducible lock (committed artifact). Best-effort: a write
   // failure must not fail an already-successful scaffold.
   try {
-    await writeLockFile(absProjectPath, buildLock({ framework, flags: userFlags, packageManager: pm }))
+    await writeLockFile(absProjectPath, buildLock({ framework, flags: userFlags, packageManager: pm, variant }))
   }
   catch {
     p.log.warn(pc.yellow(`Could not write ${LOCK_FILENAME} (project created successfully)`))
@@ -474,11 +482,8 @@ export async function runDirectExecution(
   await executePipeline(framework, projectName, preselected, cmd, options, pm, config)
 }
 
-/**
- * Frameworks whose interactive variant selection (Vite template, T3 components)
- * is not captured in the lock, so `--from-lock` cannot reproduce them yet.
- */
-const FROM_LOCK_UNSUPPORTED = new Set(['vite', 't3'])
+/** Frameworks whose reproduction needs a captured variant (Vite template, T3 components). */
+const FROM_LOCK_VARIANT_REQUIRED = new Set(['vite', 't3'])
 
 /**
  * Reproduce a project from a `tinkerise.lock` in the current directory.
@@ -507,10 +512,10 @@ export async function runFromLock(
     })
   }
 
-  if (FROM_LOCK_UNSUPPORTED.has(lock.framework)) {
+  if (FROM_LOCK_VARIANT_REQUIRED.has(lock.framework) && !lock.variant) {
     throw new TinkeriseError({
-      message: `--from-lock does not support ${lock.framework} yet (its variant selection is not captured in the lock).`,
-      code: 'LOCK_UNSUPPORTED_FRAMEWORK',
+      message: `This lock predates ${lock.framework} variant capture, so --from-lock cannot reproduce it.`,
+      code: 'LOCK_MISSING_VARIANT',
       suggestion: `Scaffold it directly, e.g. tinkerise ${lock.category} ${lock.framework} ${name}`,
     })
   }
@@ -520,5 +525,5 @@ export async function runFromLock(
     throw new ConfigValidationError('projectName', name, 'lowercase letters, numbers, hyphens, dots, underscores; max 64 chars')
   }
 
-  await runResolvedScaffold(lock.framework, name, { ...lock.flags }, options, lock.packageManager as PackageManager)
+  await runResolvedScaffold(lock.framework, name, { ...lock.flags }, options, lock.packageManager as PackageManager, lock.variant)
 }

--- a/packages/cli/src/context/lock.ts
+++ b/packages/cli/src/context/lock.ts
@@ -5,7 +5,7 @@
  * for `scaffold --from-lock` and `tinkerise update`), so it is never gitignored.
  */
 
-import type { TinkeriseLock } from '@tinkerise/shared'
+import type { LockVariant, TinkeriseLock } from '@tinkerise/shared'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getScaffolder } from '@tinkerise/core'
@@ -18,6 +18,7 @@ export interface BuildLockInput {
   framework: string
   flags: Record<string, string | boolean>
   packageManager: string
+  variant?: LockVariant
 }
 
 /**
@@ -37,6 +38,7 @@ export function buildLock(input: BuildLockInput): TinkeriseLock {
     enhancements: [],
     packageManager: input.packageManager,
     createdWith: VERSION,
+    variant: input.variant,
   })
 }
 

--- a/packages/cli/tests/commands/scaffold-wiring.test.ts
+++ b/packages/cli/tests/commands/scaffold-wiring.test.ts
@@ -295,15 +295,62 @@ describe('variant prompt wiring', () => {
       expect(mockExecuteScaffolder).not.toHaveBeenCalled()
     })
 
-    it('throws for frameworks whose variants the lock cannot capture', async () => {
+    it('throws for a lock that predates variant capture', async () => {
       mockReadLockFile.mockResolvedValue(lockFor('vite'))
 
       await expect(runFromLock('app', {})).rejects.toThrow(/vite/i)
       expect(mockExecuteScaffolder).not.toHaveBeenCalled()
     })
 
+    it('reproduces a vite project from a captured variant without prompting', async () => {
+      mockResolveViteTemplate.mockReturnValue('react-ts')
+      mockReadLockFile.mockResolvedValue({ ...lockFor('vite'), variant: { template: 'react', typescript: true } })
+
+      await runFromLock('repro', {})
+
+      expect(mockSelectViteTemplate).not.toHaveBeenCalled()
+      expect(mockResolveViteTemplate).toHaveBeenCalledWith('react', true)
+      expect(mockExecuteScaffolder).toHaveBeenCalledWith(
+        expect.objectContaining({ scaffolderName: 'vite', extraArgs: expect.arrayContaining(['--template', 'react-ts']) }),
+      )
+    })
+
+    it('reproduces a t3 project from captured components without prompting', async () => {
+      mockReadLockFile.mockResolvedValue({ ...lockFor('t3'), variant: { components: ['trpc'] } })
+
+      await runFromLock('repro', {})
+
+      expect(mockSelectT3Components).not.toHaveBeenCalled()
+      expect(mockExecuteScaffolder).toHaveBeenCalledWith(
+        expect.objectContaining({ scaffolderName: 't3', extraArgs: expect.arrayContaining(['--trpc', '--CI']) }),
+      )
+    })
+
     it('throws when no project name is provided', async () => {
       await expect(runFromLock(undefined, {})).rejects.toThrow(/name/i)
+    })
+  })
+
+  describe('lock variant capture', () => {
+    it('captures the vite template variant', async () => {
+      mockSelectViteTemplate.mockResolvedValue('react')
+      mockResolveViteTemplate.mockReturnValue('react-ts')
+
+      await runDirectExecution('web', 'vite', 'my-app', createMockCommand(), { typescript: true })
+
+      expect(mockBuildLock).toHaveBeenCalledWith(
+        expect.objectContaining({ framework: 'vite', variant: { template: 'react', typescript: true } }),
+      )
+    })
+
+    it('captures the selected t3 components', async () => {
+      mockSelectT3Components.mockResolvedValue(['trpc', 'prisma'])
+
+      await runDirectExecution('web', 't3', 'my-app', createMockCommand(), {})
+
+      expect(mockBuildLock).toHaveBeenCalledWith(
+        expect.objectContaining({ framework: 't3', variant: { components: ['trpc', 'prisma'] } }),
+      )
     })
   })
 })

--- a/packages/cli/tests/context/lock.test.ts
+++ b/packages/cli/tests/context/lock.test.ts
@@ -41,6 +41,21 @@ describe('buildLock', () => {
   it('throws on an unknown framework', () => {
     expect(() => buildLock({ framework: 'nope', flags: {}, packageManager: 'npm' })).toThrow(/nope/)
   })
+
+  it('includes a variant when provided', () => {
+    const lock = buildLock({
+      framework: 'vite',
+      flags: {},
+      packageManager: 'npm',
+      variant: { template: 'react', typescript: true },
+    })
+    expect(lock.variant).toEqual({ template: 'react', typescript: true })
+  })
+
+  it('omits the variant when not provided', () => {
+    const lock = buildLock({ framework: 'next', flags: {}, packageManager: 'npm' })
+    expect(lock.variant).toBeUndefined()
+  })
 })
 
 describe('writeLockFile', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -78,11 +78,13 @@ export type {
 export {
   LOCK_SCHEMA_VERSION,
   LockEnhancementSchema,
+  LockVariantSchema,
   TinkeriseLockSchema,
 } from './lock/index.js'
 
 export type {
   LockEnhancement,
+  LockVariant,
   TinkeriseLock,
 } from './lock/index.js'
 

--- a/packages/shared/src/lock/schema.ts
+++ b/packages/shared/src/lock/schema.ts
@@ -15,6 +15,16 @@ export const LockEnhancementSchema = z.object({
   version: z.string().nullable(),
 })
 
+/**
+ * Framework-specific variant selections that aren't plain flags — e.g. the Vite
+ * template or the T3 components. Captured so `--from-lock` can reproduce them.
+ */
+export const LockVariantSchema = z.object({
+  template: z.string().optional(),
+  typescript: z.boolean().optional(),
+  components: z.array(z.string()).optional(),
+})
+
 export const TinkeriseLockSchema = z.object({
   schemaVersion: z.literal(LOCK_SCHEMA_VERSION),
   framework: z.string(),
@@ -24,7 +34,10 @@ export const TinkeriseLockSchema = z.object({
   packageManager: z.string(),
   /** tinkerise version that produced this lock */
   createdWith: z.string(),
+  /** Framework-specific variant selections (Vite template, T3 components) */
+  variant: LockVariantSchema.optional(),
 })
 
 export type LockEnhancement = z.infer<typeof LockEnhancementSchema>
+export type LockVariant = z.infer<typeof LockVariantSchema>
 export type TinkeriseLock = z.infer<typeof TinkeriseLockSchema>

--- a/packages/shared/tests/lock/schema.test.ts
+++ b/packages/shared/tests/lock/schema.test.ts
@@ -45,4 +45,33 @@ describe('tinkeriseLockSchema', () => {
     })
     expect(parsed.success).toBe(false)
   })
+
+  it('accepts a Vite template variant', () => {
+    const parsed = TinkeriseLockSchema.safeParse({
+      ...validLock,
+      variant: { template: 'react', typescript: true },
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts a T3 components variant', () => {
+    const parsed = TinkeriseLockSchema.safeParse({
+      ...validLock,
+      variant: { components: ['trpc', 'prisma'] },
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts a lock without a variant (backward compatible)', () => {
+    const { variant: _v, ...withoutVariant } = { ...validLock, variant: undefined }
+    expect(TinkeriseLockSchema.safeParse(withoutVariant).success).toBe(true)
+  })
+
+  it('rejects a malformed variant', () => {
+    const parsed = TinkeriseLockSchema.safeParse({
+      ...validLock,
+      variant: { components: 'trpc' },
+    })
+    expect(parsed.success).toBe(false)
+  })
 })


### PR DESCRIPTION
## Tier B — capture & reproduce framework variants (Vite/T3) via the lock

Closes the `--from-lock` gap left by #47: Vite (template + TypeScript) and T3 (components) select variants interactively, so the lock couldn't reproduce them. This captures those selections and replays them.

### What it does
- **New optional `variant` field** on the lock schema (`@tinkerise/shared`): `{ template?, typescript?, components? }`. Backward-compatible — existing locks parse unchanged.
- **Capture**: `runResolvedScaffold` records the resolved Vite template + TS, or the chosen T3 components, into the lock.
- **Replay**: `runResolvedScaffold` accepts a replay variant that bypasses the (already-existing) prompt-bypass paths of `selectViteTemplate` / `selectT3Components`, so `--from-lock` runs fully non-interactively.
- **`--from-lock` now supports Vite and T3.** Locks written *before* this change surface a clear `LOCK_MISSING_VARIANT` error for those two frameworks (instead of a wrong reproduction).

### Design notes
- The capture/replay is symmetric and additive: with no replay variant, behavior is identical to before (existing scaffold suite proves it). The variant prompt's `--json` dry-run guard now only fires when a prompt would actually occur (i.e. no replay variant).
- `variant` is a dedicated field rather than overloading `flags`, keeping framework-specific selections cleanly separated from unified scaffold flags.

### Tests (TDD) + smoke
- schema: accepts Vite/T3 variants, accepts no-variant (backward compat), rejects malformed.
- `buildLock`: includes/omits the variant.
- wiring: captures the Vite template and T3 components; reproduces both from a captured variant **without prompting**; old-lock-without-variant throws.
- Smoke (built CLI): `vite-repro --from-lock --dry-run` → `npx create-vite vite-repro --template react-ts --no-interactive`; old vite lock → `LOCK_MISSING_VARIANT`.

Full gate green locally: lint, typecheck, test (89 + 665 + 476), build. Changeset included (`@tinkerise/cli` + `@tinkerise/shared` minor).
