### PR TITLE
feat(cli): --from-lock reproduces recorded enhancements too

### DIFF
--- a/.changeset/from-lock-enhancements.md
+++ b/.changeset/from-lock-enhancements.md
@@ -1,0 +1,5 @@
+---
+"@tinkerise/cli": minor
+---
+
+`tinkerise <name> --from-lock` now reproduces a project in full: after scaffolding the framework it re-applies the enhancements recorded in the lock, so one command recreates the whole stack. Dry-run remains side-effect-free (enhancements are not applied).

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -33,6 +33,7 @@ import {
   mergePromptAndFlags,
 } from '../utils/interactive.js'
 import { isJsonMode } from '../utils/output-mode.js'
+import { runAddCommand } from './add.js'
 
 /** Valid scaffolder categories */
 const VALID_CATEGORIES: ScaffolderCategory[] = ['web', 'backend', 'mobile']
@@ -526,4 +527,10 @@ export async function runFromLock(
   }
 
   await runResolvedScaffold(lock.framework, name, { ...lock.flags }, options, lock.packageManager as PackageManager, lock.variant)
+
+  // Reproduce the recorded enhancements too (skipped in dry-run, which is
+  // side-effect-free and never sets the session the add flow relies on).
+  if (!isDryRun(options) && lock.enhancements.length > 0) {
+    await runAddCommand(lock.enhancements.map(e => e.id), { verbose: options.verbose })
+  }
 }

--- a/packages/cli/tests/commands/scaffold-wiring.test.ts
+++ b/packages/cli/tests/commands/scaffold-wiring.test.ts
@@ -37,6 +37,7 @@ const {
   mockBuildLock,
   mockWriteLockFile,
   mockReadLockFile,
+  mockRunAddCommand,
 } = vi.hoisted(() => ({
   mockShowBanner: vi.fn(),
   mockRunPromptFlow: vi.fn(),
@@ -58,6 +59,11 @@ const {
   mockBuildLock: vi.fn(),
   mockWriteLockFile: vi.fn(),
   mockReadLockFile: vi.fn(),
+  mockRunAddCommand: vi.fn(),
+}))
+
+vi.mock('../../src/commands/add.js', () => ({
+  runAddCommand: mockRunAddCommand,
 }))
 
 vi.mock('../../src/context/lock.js', () => ({
@@ -126,6 +132,7 @@ vi.mock('picocolors', () => ({
     dim: (s: string) => s,
     red: (s: string) => s,
     yellow: (s: string) => s,
+    cyan: (s: string) => s,
   },
 }))
 
@@ -328,6 +335,38 @@ describe('variant prompt wiring', () => {
 
     it('throws when no project name is provided', async () => {
       await expect(runFromLock(undefined, {})).rejects.toThrow(/name/i)
+    })
+
+    it('re-applies the recorded enhancements after reproducing', async () => {
+      mockReadLockFile.mockResolvedValue({
+        ...lockFor('next'),
+        enhancements: [{ id: 'eslint', version: null }, { id: 'prettier', version: null }],
+      })
+
+      await runFromLock('repro', {})
+
+      expect(mockExecuteScaffolder).toHaveBeenCalled()
+      expect(mockRunAddCommand).toHaveBeenCalledWith(['eslint', 'prettier'], expect.anything())
+    })
+
+    it('does not re-apply enhancements on dry-run', async () => {
+      mockExecuteScaffolder.mockResolvedValue({
+        scaffolderName: 'next',
+        command: 'npx',
+        args: [],
+        prerequisites: [],
+        resolvedFlags: [],
+        versionUsed: null,
+        upstreamVersion: null,
+      })
+      mockReadLockFile.mockResolvedValue({
+        ...lockFor('next'),
+        enhancements: [{ id: 'eslint', version: null }],
+      })
+
+      await runFromLock('repro', { dryRun: true })
+
+      expect(mockRunAddCommand).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Tier B — `--from-lock` reproduces the *whole* project (framework + enhancements)

Before this, `tinkerise <name> --from-lock` recreated only the framework skeleton; the enhancements recorded in the lock were dropped, so users had to manually `cd` in and run `tinkerise add --from-lock`. "Reproduce my project" should mean the whole project.

### What it does
After scaffolding the framework, `runFromLock` re-applies the lock's recorded enhancements through the existing `runAddCommand` (which runs inside the freshly-scaffolded directory via the session context just set by the scaffold). The reproduced project also ends with an accurate lock (the `add` flow re-records the enhancements).

### Safety
- **Dry-run stays side-effect-free**: the re-apply is guarded by `!isDryRun(...)`, and dry-run also never sets the session the add flow relies on — so `--from-lock --dry-run` only renders the plan. Verified by unit test *and* smoke (dir contained only the lock afterward).
- No enhancements recorded → nothing extra runs.
- Reuses `runAddCommand` (DRY); no new execution logic. `add.ts` does not import `scaffold.ts`, so the static import introduces no cycle.

### Tests
- re-applies recorded enhancements after reproducing (asserts `runAddCommand(['eslint','prettier'], …)`);
- does NOT re-apply on dry-run;
- existing from-lock tests (no enhancements) unaffected.

Full gate green locally: lint, typecheck, test (478 CLI), build. Changeset included (`@tinkerise/cli` minor).
