### PR TITLE
docs: surface reproducible projects in README and getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ tinkerise is a unified CLI that wraps official framework scaffolders instead of 
 - **11 enhancement modules** for linting, CI, formatting, testing, Docker, and repo hygiene
 - **3 utility templates** (`mcp-server`, `cli-tool`, `npm-lib`) for greenfield tooling work
 - **Presets + layered config** so teams can standardize scaffolds without custom wrappers
+- **Reproducible projects** via a committed `tinkerise.lock` and `--from-lock` to recreate any stack in one command
 
 ## Deep dive in docs
 
 - Getting started: [https://farce1.github.io/tinkerise/guides/getting-started/](https://farce1.github.io/tinkerise/guides/getting-started/)
 - Scaffolder guides: [https://farce1.github.io/tinkerise/guides/scaffolders/](https://farce1.github.io/tinkerise/guides/scaffolders/)
 - Enhancement guides: [https://farce1.github.io/tinkerise/guides/enhancements/](https://farce1.github.io/tinkerise/guides/enhancements/)
+- Reproducible projects: [https://farce1.github.io/tinkerise/guides/reproducible-projects/](https://farce1.github.io/tinkerise/guides/reproducible-projects/)
 - Command reference: [https://farce1.github.io/tinkerise/reference/commands/](https://farce1.github.io/tinkerise/reference/commands/)
 
 For the full guide catalog and recipes, visit [https://farce1.github.io/tinkerise/](https://farce1.github.io/tinkerise/).

--- a/apps/docs/src/content/docs/guides/getting-started.mdx
+++ b/apps/docs/src/content/docs/guides/getting-started.mdx
@@ -117,5 +117,6 @@ tinkerise add prettier husky
 
 - Browse framework guides in [`/guides/scaffolders/`](/tinkerise/guides/scaffolders/)
 - Explore enhancement modules in [`/guides/enhancements/`](/tinkerise/guides/enhancements/)
+- Recreate a stack anywhere with [Reproducible Projects](/tinkerise/guides/reproducible-projects/)
 - See every command and flag in [`/reference/commands/`](/tinkerise/reference/commands/)
 - Follow end-to-end setups in [`/recipes/`](/tinkerise/recipes/)


### PR DESCRIPTION
Make the shipped `tinkerise.lock` / `--from-lock` workflow discoverable from the main entry points (the dedicated guide landed in #50).

- **README**: a Feature snapshot bullet for reproducible projects + a Deep-dive link to the guide.
- **Getting Started**: a "Where to go next" link to the Reproducible Projects guide.

Docs-only (README + Starlight guide). `bun run docs:build` green (40 pages, links resolve). No changeset (no published-package change).