### PR TITLE
feat: source trust store + per-source consent gate (Tier C foundation)

### DIFF
--- a/.changeset/tier3-trust-store.md
+++ b/.changeset/tier3-trust-store.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/core": minor
+"@tinkerise/shared": minor
+---
+
+Add the Tier C foundation for external sources: a persisted trust store and a per-source consent gate (`ensureSourceTrusted`). No source is ever loaded or executed without explicit, per-source consent, which is remembered across runs. The consent prompt is supplied by the caller (callback-decoupled, like the enhancement conflict callbacks), so core stays UI-free.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,19 @@ export { getScaffolderMetadata, SCAFFOLDER_METADATA } from './registry/metadata.
 export type { ScaffolderMetadata } from './registry/metadata.js'
 
 /**
+ * Sources — trust store and per-source consent gate for external sources (Tier C).
+ */
+export {
+  ensureSourceTrusted,
+  getTrustStorePath,
+  isSourceTrusted,
+  listTrustedSources,
+  TRUST_STORE_FILENAME,
+  trustSource,
+} from './sources/index.js'
+export type { OnSourceConsent, SourceConsentRequest } from './sources/index.js'
+
+/**
  * Templates — utility project generators (MCP server, CLI tool, npm library).
  */
 export { generateCliTool, generateLib, generateMcpServer, TEMPLATE_METADATA } from './templates/index.js'

--- a/packages/core/src/sources/index.ts
+++ b/packages/core/src/sources/index.ts
@@ -1,0 +1,1 @@
+export * from './trust-store.js'

--- a/packages/core/src/sources/trust-store.ts
+++ b/packages/core/src/sources/trust-store.ts
@@ -37,8 +37,11 @@ async function readTrustStore(): Promise<TrustStore> {
 }
 
 async function writeTrustStore(store: TrustStore): Promise<void> {
+  // Validate before persisting so a logic regression can never write a malformed
+  // trust store (mirrors saveGlobalConfig; this file gates external-source trust).
+  const validated = TrustStoreSchema.parse(store)
   await mkdir(getConfigDir(), { recursive: true })
-  await writeFile(getTrustStorePath(), `${JSON.stringify(store, null, 2)}\n`, 'utf-8')
+  await writeFile(getTrustStorePath(), `${JSON.stringify(validated, null, 2)}\n`, 'utf-8')
 }
 
 export async function listTrustedSources(): Promise<TrustedSource[]> {

--- a/packages/core/src/sources/trust-store.ts
+++ b/packages/core/src/sources/trust-store.ts
@@ -1,0 +1,74 @@
+/**
+ * Source trust store (Tier C) — persists which external sources the user has
+ * explicitly consented to. The consent prompt itself is UI, so `ensureSourceTrusted`
+ * takes a callback (mirroring the enhancement conflict/approval callbacks); core
+ * never prompts directly.
+ */
+
+import type { TrustedSource, TrustStore } from '@tinkerise/shared'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { TRUST_STORE_VERSION, TrustStoreSchema } from '@tinkerise/shared'
+import { getConfigDir } from '../config/index.js'
+
+/** Trust store filename in the config dir. */
+export const TRUST_STORE_FILENAME = 'trusted-sources.json'
+
+export function getTrustStorePath(): string {
+  return path.join(getConfigDir(), TRUST_STORE_FILENAME)
+}
+
+/** Details passed to the consent callback so the UI can describe what is being trusted. */
+export interface SourceConsentRequest {
+  id: string
+}
+
+export type OnSourceConsent = (source: SourceConsentRequest) => Promise<boolean>
+
+async function readTrustStore(): Promise<TrustStore> {
+  const empty: TrustStore = { version: TRUST_STORE_VERSION, sources: [] }
+  try {
+    const parsed = TrustStoreSchema.safeParse(JSON.parse(await readFile(getTrustStorePath(), 'utf-8')))
+    return parsed.success ? parsed.data : empty
+  }
+  catch {
+    return empty
+  }
+}
+
+async function writeTrustStore(store: TrustStore): Promise<void> {
+  await mkdir(getConfigDir(), { recursive: true })
+  await writeFile(getTrustStorePath(), `${JSON.stringify(store, null, 2)}\n`, 'utf-8')
+}
+
+export async function listTrustedSources(): Promise<TrustedSource[]> {
+  return (await readTrustStore()).sources
+}
+
+export async function isSourceTrusted(id: string): Promise<boolean> {
+  return (await readTrustStore()).sources.some(s => s.id === id)
+}
+
+/** Persist consent for a source. Idempotent — re-trusting keeps the original entry. */
+export async function trustSource(id: string): Promise<void> {
+  const store = await readTrustStore()
+  if (store.sources.some(s => s.id === id))
+    return
+  store.sources.push({ id, trustedAt: new Date().toISOString() })
+  await writeTrustStore(store)
+}
+
+/**
+ * Gate any use of an external source on explicit per-source consent. Returns true
+ * if the source is already trusted, or if the consent callback grants it (which
+ * also persists the trust). Returns false — without trusting — when consent is denied.
+ */
+export async function ensureSourceTrusted(id: string, onConsent: OnSourceConsent): Promise<boolean> {
+  if (await isSourceTrusted(id))
+    return true
+
+  const granted = await onConsent({ id })
+  if (granted)
+    await trustSource(id)
+  return granted
+}

--- a/packages/core/tests/sources/trust-store.test.ts
+++ b/packages/core/tests/sources/trust-store.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureSourceTrusted,
+  getTrustStorePath,
+  isSourceTrusted,
+  listTrustedSources,
+  trustSource,
+} from '../../src/sources/trust-store'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = path.join(os.tmpdir(), `tinkerise-trust-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  await mkdir(tmpDir, { recursive: true })
+  vi.stubEnv('XDG_CONFIG_HOME', tmpDir)
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('trust store', () => {
+  it('places the store inside the config dir', () => {
+    expect(getTrustStorePath()).toBe(path.join(tmpDir, 'tinkerise', 'trusted-sources.json'))
+  })
+
+  it('reports untrusted sources when the store is empty', async () => {
+    expect(await isSourceTrusted('npm:foo')).toBe(false)
+    expect(await listTrustedSources()).toEqual([])
+  })
+
+  it('trusts a source and persists it', async () => {
+    await trustSource('npm:foo')
+
+    expect(await isSourceTrusted('npm:foo')).toBe(true)
+    const sources = await listTrustedSources()
+    expect(sources.map(s => s.id)).toEqual(['npm:foo'])
+    expect(typeof sources[0]!.trustedAt).toBe('string')
+    expect(sources[0]!.trustedAt.length).toBeGreaterThan(0)
+  })
+
+  it('does not duplicate an already-trusted source', async () => {
+    await trustSource('npm:foo')
+    await trustSource('npm:foo')
+
+    expect((await listTrustedSources()).filter(s => s.id === 'npm:foo')).toHaveLength(1)
+  })
+})
+
+describe('ensureSourceTrusted', () => {
+  it('returns true without prompting when already trusted', async () => {
+    await trustSource('npm:foo')
+    const onConsent = vi.fn(async () => false)
+
+    expect(await ensureSourceTrusted('npm:foo', onConsent)).toBe(true)
+    expect(onConsent).not.toHaveBeenCalled()
+  })
+
+  it('prompts and trusts the source when consent is granted', async () => {
+    const onConsent = vi.fn(async () => true)
+
+    expect(await ensureSourceTrusted('npm:foo', onConsent)).toBe(true)
+    expect(onConsent).toHaveBeenCalledWith({ id: 'npm:foo' })
+    expect(await isSourceTrusted('npm:foo')).toBe(true)
+  })
+
+  it('does not trust the source when consent is denied', async () => {
+    const onConsent = vi.fn(async () => false)
+
+    expect(await ensureSourceTrusted('npm:foo', onConsent)).toBe(false)
+    expect(await isSourceTrusted('npm:foo')).toBe(false)
+  })
+})

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -107,3 +107,17 @@ export type {
   ScaffolderEntry,
   VersionedFlagMap,
 } from './registry/index.js'
+
+/**
+ * Sources — trust store schema for external scaffolder/enhancement sources (Tier C).
+ */
+export {
+  TRUST_STORE_VERSION,
+  TrustedSourceSchema,
+  TrustStoreSchema,
+} from './sources/index.js'
+
+export type {
+  TrustedSource,
+  TrustStore,
+} from './sources/index.js'

--- a/packages/shared/src/sources/index.ts
+++ b/packages/shared/src/sources/index.ts
@@ -1,0 +1,1 @@
+export * from './schema.js'

--- a/packages/shared/src/sources/schema.ts
+++ b/packages/shared/src/sources/schema.ts
@@ -1,0 +1,24 @@
+/**
+ * Trust store schema (Tier C) — records the external sources a user has
+ * explicitly consented to before tinkerise loads or runs anything from them.
+ */
+import { z } from 'zod'
+
+/** Trust store version. Bump on any breaking shape change. */
+export const TRUST_STORE_VERSION = 1
+
+/** A single source the user has consented to trust. */
+export const TrustedSourceSchema = z.object({
+  /** Canonical source id, e.g. `npm:tinkerise-scaffolder-foo` or `github:org/repo`. */
+  id: z.string(),
+  /** ISO timestamp of when consent was granted. */
+  trustedAt: z.string(),
+})
+
+export const TrustStoreSchema = z.object({
+  version: z.literal(TRUST_STORE_VERSION),
+  sources: z.array(TrustedSourceSchema),
+})
+
+export type TrustedSource = z.infer<typeof TrustedSourceSchema>
+export type TrustStore = z.infer<typeof TrustStoreSchema>

--- a/packages/shared/tests/sources/schema.test.ts
+++ b/packages/shared/tests/sources/schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { TRUST_STORE_VERSION, TrustedSourceSchema, TrustStoreSchema } from '../../src/sources/schema.js'
+
+const validStore = {
+  version: TRUST_STORE_VERSION,
+  sources: [
+    { id: 'npm:tinkerise-scaffolder-foo', trustedAt: '2026-06-14T10:00:00.000Z' },
+    { id: 'github:org/repo', trustedAt: '2026-06-14T10:01:00.000Z' },
+  ],
+}
+
+describe('trustStoreSchema', () => {
+  it('accepts a valid store', () => {
+    expect(TrustStoreSchema.safeParse(validStore).success).toBe(true)
+  })
+
+  it('accepts an empty source list', () => {
+    expect(TrustStoreSchema.safeParse({ version: TRUST_STORE_VERSION, sources: [] }).success).toBe(true)
+  })
+
+  it('rejects a mismatched version', () => {
+    expect(TrustStoreSchema.safeParse({ ...validStore, version: 2 }).success).toBe(false)
+  })
+
+  it('rejects a source missing trustedAt', () => {
+    expect(TrustStoreSchema.safeParse({
+      version: TRUST_STORE_VERSION,
+      sources: [{ id: 'npm:x' }],
+    }).success).toBe(false)
+  })
+})
+
+describe('trustedSourceSchema', () => {
+  it('requires id and trustedAt', () => {
+    expect(TrustedSourceSchema.safeParse({ id: 'npm:x', trustedAt: '2026-06-14T10:00:00.000Z' }).success).toBe(true)
+    expect(TrustedSourceSchema.safeParse({ id: 'npm:x' }).success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Tier C foundation — source trust store + per-source consent gate

First step of Tier C (open the registry to external sources), built **security-first**: the consent gate that every later step (npm discovery, remote resolution, third-party execution) must pass through. Per the agreed design, trust is **explicit and per-source**.

### What it does
- **`@tinkerise/shared`**: `TrustStoreSchema` / `TrustedSourceSchema` (Zod) — `{ version, sources: [{ id, trustedAt }] }`.
- **`@tinkerise/core`** (`sources/trust-store.ts`), persisted at `<config-dir>/trusted-sources.json`:
  - `isSourceTrusted(id)`, `trustSource(id)` (idempotent), `listTrustedSources()`
  - **`ensureSourceTrusted(id, onConsent)`** — the gate: returns `true` if already trusted; otherwise calls the consent callback and, only on approval, persists trust and returns `true`; denial returns `false` and persists nothing.

### Design
- **Per-source, remembered consent**: each distinct source id (`npm:…`, `github:org/repo`, …) is consented once and remembered across runs.
- **UI-free core**: the actual prompt is supplied by the caller (the CLI, in a later PR), mirroring the existing `onConflict` / `onDependencyApproval` callback decoupling.
- **Fail-safe reads**: a missing or invalid store reads as empty (no source is implicitly trusted).
- **No remote code executes in this PR** — this is purely the consent primitive; resolver/discovery/execution land in follow-ups, each gated through `ensureSourceTrusted`.

### Tests (TDD)
- shared: schema accept/reject (version, required fields).
- core: store path in config dir; empty-store reads; trust + persist; idempotent re-trust; gate returns true-without-prompt when trusted, trusts on consent, and does not trust on denial.

Full gate green locally: lint, typecheck, test (94 + 672 + 478), build. Changeset included (`@tinkerise/core` + `@tinkerise/shared` minor).
