### PR TITLE
feat: source resolver + tinkerise trust command (Tier C)

### DIFF
--- a/.changeset/tier3-trust-command.md
+++ b/.changeset/tier3-trust-command.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/core": minor
+---
+
+Add `tinkerise trust` to manage external sources: `trust list`, `trust add <source>`, and `trust remove <source>`, where a source is `npm:<package>` or `github:<owner>/<repo>`. A new `parseSource` resolver canonicalizes specifiers (case-normalized) so trust cannot be bypassed by format variation, and invalid specs surface a clear `INVALID_SOURCE` error. Builds on the Tier C trust store; no external code is executed yet.

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -1,0 +1,67 @@
+/**
+ * `tinkerise trust` command — manage the external sources tinkerise may load.
+ *
+ * Subcommands:
+ * - `trust list` — show trusted sources
+ * - `trust add <source>` — trust a source (npm:<package> or github:<owner>/<repo>)
+ * - `trust remove <source>` — revoke trust
+ *
+ * Running `trust add` is itself explicit consent, so it trusts directly; the
+ * interactive consent prompt is for sources encountered implicitly (later).
+ */
+
+import type { Command } from 'commander'
+import { listTrustedSources, parseSource, trustSource, untrustSource } from '@tinkerise/core'
+import pc from 'picocolors'
+import { log } from '../utils/clack-output.js'
+
+export function registerTrustCommand(program: Command): void {
+  const programName = program.name()
+
+  const trust = program
+    .command('trust')
+    .summary('Manage trusted external sources')
+    .description('List, add, or remove the external sources tinkerise may load (npm:<package>, github:<owner>/<repo>).')
+    .addHelpText('after', `
+Examples:
+  $ ${programName} trust list                       Show trusted sources
+  $ ${programName} trust add github:acme/widgets    Trust a source
+  $ ${programName} trust remove github:acme/widgets Revoke trust`)
+
+  trust
+    .command('list')
+    .description('Show trusted external sources')
+    .action(async () => {
+      const sources = await listTrustedSources()
+      if (sources.length === 0) {
+        log.info('No trusted sources.')
+        return
+      }
+      for (const s of sources) {
+        log.info(`  ${s.id} ${pc.dim(`(trusted ${s.trustedAt})`)}`)
+      }
+    })
+
+  trust
+    .command('add <source>')
+    .description('Trust an external source (npm:<package> or github:<owner>/<repo>)')
+    .action(async (source: string) => {
+      const { id } = parseSource(source)
+      await trustSource(id)
+      log.success(`Trusted ${id}`)
+    })
+
+  trust
+    .command('remove <source>')
+    .description('Revoke trust for an external source')
+    .action(async (source: string) => {
+      const { id } = parseSource(source)
+      const removed = await untrustSource(id)
+      if (removed) {
+        log.success(`Removed ${id}`)
+      }
+      else {
+        log.info(`${id} was not trusted.`)
+      }
+    })
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { listScaffolders } from './commands/list.js'
 import { registerMcpCommand } from './commands/mcp.js'
 import { registerPresetCommand } from './commands/preset.js'
 import { runCategoryFlow, runDirectExecution, runFromLock, runInteractiveFlow } from './commands/scaffold.js'
+import { registerTrustCommand } from './commands/trust.js'
 import { registerUpdateCommand } from './commands/update.js'
 import { handleError } from './utils/error-handler.js'
 import { detectJsonMode, isJsonMode } from './utils/output-mode.js'
@@ -201,6 +202,9 @@ registerConfigCommand(program)
 // Preset command — manage configuration presets
 registerPresetCommand(program)
 
+// Trust command — manage trusted external sources (Tier C)
+registerTrustCommand(program)
+
 // MCP command — scaffold MCP server projects
 registerMcpCommand(program)
 
@@ -241,6 +245,8 @@ Examples:
   $ ${programName} preset use my-stack        Apply a saved preset
   $ ${programName} preset list                Show available presets
   $ ${programName} preset delete my-stack     Remove a preset
+  $ ${programName} trust list                 Show trusted external sources
+  $ ${programName} trust add github:acme/widgets  Trust an external source
   $ ${programName} web next my-app --preset my-stack  Apply preset to scaffold
   $ ${programName} mcp my-server              Scaffold an MCP server
   $ ${programName} cli my-tool                Scaffold a CLI tool

--- a/packages/cli/tests/commands/trust.test.ts
+++ b/packages/cli/tests/commands/trust.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the `tinkerise trust` command.
+ *
+ * Verifies:
+ * - trust add canonicalizes the source and persists trust
+ * - trust remove canonicalizes and revokes
+ * - trust list reads the store
+ * - invalid source specs are rejected
+ */
+
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerTrustCommand } from '../../src/commands/trust.js'
+
+const { mockListTrustedSources, mockTrustSource, mockUntrustSource } = vi.hoisted(() => ({
+  mockListTrustedSources: vi.fn(),
+  mockTrustSource: vi.fn(),
+  mockUntrustSource: vi.fn(),
+}))
+
+vi.mock('@tinkerise/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tinkerise/core')>()
+  return {
+    ...actual,
+    listTrustedSources: mockListTrustedSources,
+    trustSource: mockTrustSource,
+    untrustSource: mockUntrustSource,
+  }
+})
+
+vi.mock('@clack/prompts', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('picocolors', () => ({
+  default: { dim: (s: string) => s },
+}))
+
+async function runTrust(args: string[]): Promise<void> {
+  const program = new Command()
+  program.exitOverride()
+  registerTrustCommand(program)
+  await program.parseAsync(['node', 'tinkerise', 'trust', ...args])
+}
+
+describe('trust command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListTrustedSources.mockResolvedValue([])
+    mockTrustSource.mockResolvedValue(undefined)
+    mockUntrustSource.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('trusts a source using its canonical id', async () => {
+    await runTrust(['add', 'github:Acme/Widgets'])
+    expect(mockTrustSource).toHaveBeenCalledWith('github:acme/widgets')
+  })
+
+  it('revokes trust using the canonical id', async () => {
+    await runTrust(['remove', 'npm:Foo'])
+    expect(mockUntrustSource).toHaveBeenCalledWith('npm:foo')
+  })
+
+  it('lists trusted sources', async () => {
+    mockListTrustedSources.mockResolvedValue([{ id: 'npm:foo', trustedAt: '2026-06-14T00:00:00.000Z' }])
+    await runTrust(['list'])
+    expect(mockListTrustedSources).toHaveBeenCalled()
+  })
+
+  it('rejects an invalid source spec', async () => {
+    await expect(runTrust(['add', 'not-a-source'])).rejects.toThrow(/source/i)
+    expect(mockTrustSource).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,10 +182,12 @@ export {
   getTrustStorePath,
   isSourceTrusted,
   listTrustedSources,
+  parseSource,
   TRUST_STORE_FILENAME,
   trustSource,
+  untrustSource,
 } from './sources/index.js'
-export type { OnSourceConsent, SourceConsentRequest } from './sources/index.js'
+export type { OnSourceConsent, ResolvedSource, SourceConsentRequest, SourceKind } from './sources/index.js'
 
 /**
  * Templates — utility project generators (MCP server, CLI tool, npm library).

--- a/packages/core/src/sources/index.ts
+++ b/packages/core/src/sources/index.ts
@@ -1,1 +1,2 @@
+export * from './resolve.js'
 export * from './trust-store.js'

--- a/packages/core/src/sources/resolve.ts
+++ b/packages/core/src/sources/resolve.ts
@@ -1,0 +1,41 @@
+/**
+ * External source resolver (Tier C) — parse a user-supplied source specifier
+ * into a canonical, case-normalized id. Canonicalization is security-relevant:
+ * the trust store keys on `id`, so `github:Acme/Repo` and `github:acme/repo`
+ * must resolve to the same id (no trust bypass via format variation).
+ */
+
+import { TinkeriseError } from '../errors/index.js'
+
+export type SourceKind = 'npm' | 'github'
+
+export interface ResolvedSource {
+  kind: SourceKind
+  /** Canonical trust-store id, e.g. `npm:foo` or `github:owner/repo`. */
+  id: string
+}
+
+const NPM_RE = /^npm:(@[a-z0-9][\w.-]*\/[a-z0-9][\w.-]*|[a-z0-9][\w.-]*)$/i
+const GITHUB_RE = /^github:([a-z0-9][\w.-]*)\/([a-z0-9][\w.-]*)$/i
+
+/**
+ * Parse `npm:<package>` or `github:<owner>/<repo>` into a canonical source.
+ * Throws on anything unrecognized.
+ */
+export function parseSource(spec: string): ResolvedSource {
+  const trimmed = spec.trim()
+
+  const npm = NPM_RE.exec(trimmed)
+  if (npm)
+    return { kind: 'npm', id: `npm:${npm[1]!.toLowerCase()}` }
+
+  const github = GITHUB_RE.exec(trimmed)
+  if (github)
+    return { kind: 'github', id: `github:${github[1]!.toLowerCase()}/${github[2]!.toLowerCase()}` }
+
+  throw new TinkeriseError({
+    message: `Unrecognized source '${spec}'.`,
+    code: 'INVALID_SOURCE',
+    suggestion: 'Use npm:<package> or github:<owner>/<repo>.',
+  })
+}

--- a/packages/core/src/sources/trust-store.ts
+++ b/packages/core/src/sources/trust-store.ts
@@ -61,6 +61,16 @@ export async function trustSource(id: string): Promise<void> {
   await writeTrustStore(store)
 }
 
+/** Revoke trust for a source. Returns true if it was present and removed. */
+export async function untrustSource(id: string): Promise<boolean> {
+  const store = await readTrustStore()
+  const remaining = store.sources.filter(s => s.id !== id)
+  if (remaining.length === store.sources.length)
+    return false
+  await writeTrustStore({ ...store, sources: remaining })
+  return true
+}
+
 /**
  * Gate any use of an external source on explicit per-source consent. Returns true
  * if the source is already trusted, or if the consent callback grants it (which

--- a/packages/core/tests/sources/resolve.test.ts
+++ b/packages/core/tests/sources/resolve.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { parseSource } from '../../src/sources/resolve'
+
+describe('parseSource', () => {
+  it('parses an unscoped npm source', () => {
+    expect(parseSource('npm:tinkerise-scaffolder-foo')).toEqual({
+      kind: 'npm',
+      id: 'npm:tinkerise-scaffolder-foo',
+    })
+  })
+
+  it('parses a scoped npm source', () => {
+    expect(parseSource('npm:@acme/tinkerise-scaffolder-foo')).toEqual({
+      kind: 'npm',
+      id: 'npm:@acme/tinkerise-scaffolder-foo',
+    })
+  })
+
+  it('parses a github source', () => {
+    expect(parseSource('github:acme/widgets')).toEqual({
+      kind: 'github',
+      id: 'github:acme/widgets',
+    })
+  })
+
+  it('canonicalizes case so trust cannot be bypassed by format', () => {
+    expect(parseSource('github:Acme/Widgets').id).toBe('github:acme/widgets')
+    expect(parseSource('  github:acme/widgets  ').id).toBe('github:acme/widgets')
+  })
+
+  it('throws on an unrecognized source', () => {
+    expect(() => parseSource('widgets')).toThrow(/source/i)
+    expect(() => parseSource('https://example.com/x')).toThrow(/source/i)
+    expect(() => parseSource('npm:')).toThrow(/source/i)
+    expect(() => parseSource('github:nope')).toThrow(/source/i)
+  })
+})

--- a/packages/core/tests/sources/trust-store.test.ts
+++ b/packages/core/tests/sources/trust-store.test.ts
@@ -8,6 +8,7 @@ import {
   isSourceTrusted,
   listTrustedSources,
   trustSource,
+  untrustSource,
 } from '../../src/sources/trust-store'
 
 let tmpDir: string
@@ -48,6 +49,14 @@ describe('trust store', () => {
     await trustSource('npm:foo')
 
     expect((await listTrustedSources()).filter(s => s.id === 'npm:foo')).toHaveLength(1)
+  })
+
+  it('untrusts a source and reports whether it was removed', async () => {
+    await trustSource('npm:foo')
+
+    expect(await untrustSource('npm:foo')).toBe(true)
+    expect(await isSourceTrusted('npm:foo')).toBe(false)
+    expect(await untrustSource('npm:foo')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Tier C — source resolver + `tinkerise trust` command

Second Tier C step: a user-facing surface for the trust foundation (#53), plus the source resolver that everything downstream depends on. Still **no external code executes** — this is management + parsing only.

### What it does
- **`@tinkerise/core` — `parseSource(spec)`**: parses `npm:<package>` or `github:<owner>/<repo>` into a canonical, **case-normalized** `{ kind, id }`. Canonicalization is security-relevant: `github:Acme/Repo` and `github:acme/repo` resolve to the same trust id, so trust can't be bypassed by format variation. Invalid specs throw a structured `INVALID_SOURCE` error.
- **`@tinkerise/core` — `untrustSource(id)`**: revoke trust (returns whether it was present).
- **`@tinkerise/cli` — `tinkerise trust`**: `list`, `add <source>`, `remove <source>`. Running `trust add` is itself explicit consent, so it trusts directly; the interactive consent *prompt* is reserved for sources encountered implicitly (next PR).

### Tests + smoke
- core: resolver (npm/scoped/github/case-normalization/invalid); `untrustSource` present/absent.
- cli: `trust add` persists the canonical id; `remove` revokes the canonical id; `list` reads the store; invalid spec rejected.
- Built-CLI smoke: `trust add github:Acme/Widgets` → stored as `github:acme/widgets`; `list`/`remove` work; invalid spec renders a clean `[INVALID_SOURCE]` user error (not "unexpected runtime failure").

Full gate green locally: lint, typecheck, test (94 + 678 + 482), build. Changeset included (`@tinkerise/cli` + `@tinkerise/core` minor).
