### PR TITLE
feat: discover installed external sources in trust list (Tier C)

### DIFF
--- a/.changeset/tier3-source-discovery.md
+++ b/.changeset/tier3-source-discovery.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/core": minor
+---
+
+`tinkerise trust list` now also surfaces installed-but-untrusted source packages (`tinkerise-scaffolder-*` / `tinkerise-enhancement-*`) found in the current project, so you can see what's available and grant trust. Adds `discoverNpmSources` (offline package.json scan, mirroring npm preset discovery; listing only — nothing is loaded or executed).

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -35,7 +35,8 @@ Examples:
       const trusted = await listTrustedSources()
       const trustedIds = new Set(trusted.map(s => s.id))
       const untrusted = (await discoverNpmSources(process.cwd()))
-        .map(pkg => `npm:${pkg}`)
+        // Canonicalize like parseSource (lowercase) so dedup against trusted ids is exact.
+        .map(pkg => `npm:${pkg.toLowerCase()}`)
         .filter(id => !trustedIds.has(id))
 
       if (trusted.length === 0 && untrusted.length === 0) {

--- a/packages/cli/src/commands/trust.ts
+++ b/packages/cli/src/commands/trust.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Command } from 'commander'
-import { listTrustedSources, parseSource, trustSource, untrustSource } from '@tinkerise/core'
+import { discoverNpmSources, listTrustedSources, parseSource, trustSource, untrustSource } from '@tinkerise/core'
 import pc from 'picocolors'
 import { log } from '../utils/clack-output.js'
 
@@ -30,15 +30,31 @@ Examples:
 
   trust
     .command('list')
-    .description('Show trusted external sources')
+    .description('Show trusted external sources and installed-but-untrusted ones')
     .action(async () => {
-      const sources = await listTrustedSources()
-      if (sources.length === 0) {
+      const trusted = await listTrustedSources()
+      const trustedIds = new Set(trusted.map(s => s.id))
+      const untrusted = (await discoverNpmSources(process.cwd()))
+        .map(pkg => `npm:${pkg}`)
+        .filter(id => !trustedIds.has(id))
+
+      if (trusted.length === 0 && untrusted.length === 0) {
         log.info('No trusted sources.')
         return
       }
-      for (const s of sources) {
-        log.info(`  ${s.id} ${pc.dim(`(trusted ${s.trustedAt})`)}`)
+
+      if (trusted.length > 0) {
+        log.info(pc.bold('Trusted sources:'))
+        for (const s of trusted) {
+          log.info(`  ${s.id} ${pc.dim(`(trusted ${s.trustedAt})`)}`)
+        }
+      }
+
+      if (untrusted.length > 0) {
+        log.info(pc.bold('Installed, not trusted:'))
+        for (const id of untrusted) {
+          log.info(`  ${id} ${pc.dim('(run trust add to use)')}`)
+        }
       }
     })
 

--- a/packages/cli/tests/commands/trust.test.ts
+++ b/packages/cli/tests/commands/trust.test.ts
@@ -12,10 +12,12 @@ import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerTrustCommand } from '../../src/commands/trust.js'
 
-const { mockListTrustedSources, mockTrustSource, mockUntrustSource } = vi.hoisted(() => ({
+const { mockListTrustedSources, mockTrustSource, mockUntrustSource, mockDiscoverNpmSources, mockLogInfo } = vi.hoisted(() => ({
   mockListTrustedSources: vi.fn(),
   mockTrustSource: vi.fn(),
   mockUntrustSource: vi.fn(),
+  mockDiscoverNpmSources: vi.fn(),
+  mockLogInfo: vi.fn(),
 }))
 
 vi.mock('@tinkerise/core', async (importOriginal) => {
@@ -25,15 +27,16 @@ vi.mock('@tinkerise/core', async (importOriginal) => {
     listTrustedSources: mockListTrustedSources,
     trustSource: mockTrustSource,
     untrustSource: mockUntrustSource,
+    discoverNpmSources: mockDiscoverNpmSources,
   }
 })
 
 vi.mock('@clack/prompts', () => ({
-  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  log: { info: mockLogInfo, success: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
 
 vi.mock('picocolors', () => ({
-  default: { dim: (s: string) => s },
+  default: { dim: (s: string) => s, bold: (s: string) => s },
 }))
 
 async function runTrust(args: string[]): Promise<void> {
@@ -49,6 +52,7 @@ describe('trust command', () => {
     mockListTrustedSources.mockResolvedValue([])
     mockTrustSource.mockResolvedValue(undefined)
     mockUntrustSource.mockResolvedValue(true)
+    mockDiscoverNpmSources.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -69,6 +73,18 @@ describe('trust command', () => {
     mockListTrustedSources.mockResolvedValue([{ id: 'npm:foo', trustedAt: '2026-06-14T00:00:00.000Z' }])
     await runTrust(['list'])
     expect(mockListTrustedSources).toHaveBeenCalled()
+  })
+
+  it('shows installed-but-untrusted sources', async () => {
+    mockListTrustedSources.mockResolvedValue([{ id: 'npm:tinkerise-enhancement-trusted', trustedAt: '2026-06-14T00:00:00.000Z' }])
+    mockDiscoverNpmSources.mockResolvedValue(['tinkerise-enhancement-trusted', 'tinkerise-scaffolder-new'])
+
+    await runTrust(['list'])
+
+    const output = mockLogInfo.mock.calls.map(c => String(c[0])).join('\n')
+    expect(output).toContain('npm:tinkerise-scaffolder-new')
+    // already-trusted discovered packages are not duplicated into the untrusted list
+    expect(output).not.toMatch(/not trusted[\s\S]*tinkerise-enhancement-trusted/)
   })
 
   it('rejects an invalid source spec', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,6 +178,7 @@ export type { ScaffolderMetadata } from './registry/metadata.js'
  * Sources — trust store and per-source consent gate for external sources (Tier C).
  */
 export {
+  discoverNpmSources,
   ensureSourceTrusted,
   getTrustStorePath,
   isSourceTrusted,

--- a/packages/core/src/sources/discovery.ts
+++ b/packages/core/src/sources/discovery.ts
@@ -1,0 +1,42 @@
+/**
+ * npm source discovery (Tier C) — find installed tinkerise-scaffolder-* and
+ * tinkerise-enhancement-* packages in a project's package.json. Mirrors
+ * discoverNpmPresets; offline and side-effect-free (listing only, no load).
+ */
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+/** Unscoped prefixes for external source packages. */
+const SOURCE_PREFIXES = ['tinkerise-scaffolder-', 'tinkerise-enhancement-']
+
+/** Pattern for scoped packages like @org/tinkerise-scaffolder-x. */
+const SCOPED_SOURCE_PATTERN = /^@.+\/tinkerise-(?:scaffolder|enhancement)-/
+
+function isSourcePackage(name: string): boolean {
+  return SOURCE_PREFIXES.some(p => name.startsWith(p)) || SCOPED_SOURCE_PATTERN.test(name)
+}
+
+/**
+ * Discover external source packages declared in a project's package.json
+ * (dependencies + devDependencies). Returns an empty array when the file is
+ * missing or has no matching packages.
+ */
+export async function discoverNpmSources(projectDir: string): Promise<string[]> {
+  try {
+    const pkg: unknown = JSON.parse(await readFile(path.join(projectDir, 'package.json'), 'utf-8'))
+    if (typeof pkg !== 'object' || pkg === null)
+      return []
+
+    const record = pkg as Record<string, unknown>
+    const names = (key: string): string[] =>
+      (typeof record[key] === 'object' && record[key] !== null)
+        ? Object.keys(record[key] as Record<string, unknown>)
+        : []
+
+    return [...names('dependencies'), ...names('devDependencies')].filter(isSourcePackage)
+  }
+  catch {
+    return []
+  }
+}

--- a/packages/core/src/sources/index.ts
+++ b/packages/core/src/sources/index.ts
@@ -1,2 +1,3 @@
+export * from './discovery.js'
 export * from './resolve.js'
 export * from './trust-store.js'

--- a/packages/core/tests/sources/discovery.test.ts
+++ b/packages/core/tests/sources/discovery.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { discoverNpmSources } from '../../src/sources/discovery'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'tinkerise-src-discovery-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+async function writePkg(pkg: unknown): Promise<void> {
+  await writeFile(join(dir, 'package.json'), JSON.stringify(pkg), 'utf-8')
+}
+
+describe('discoverNpmSources', () => {
+  it('finds scaffolder and enhancement packages in deps and devDeps', async () => {
+    await writePkg({
+      dependencies: { 'tinkerise-scaffolder-svelte': '^1.0.0', 'react': '^18' },
+      devDependencies: { 'tinkerise-enhancement-biome': '^1.0.0' },
+    })
+
+    expect((await discoverNpmSources(dir)).sort()).toEqual([
+      'tinkerise-enhancement-biome',
+      'tinkerise-scaffolder-svelte',
+    ])
+  })
+
+  it('finds scoped source packages', async () => {
+    await writePkg({
+      dependencies: {
+        '@acme/tinkerise-scaffolder-x': '^1.0.0',
+        '@acme/tinkerise-enhancement-y': '^1.0.0',
+      },
+    })
+
+    expect((await discoverNpmSources(dir)).sort()).toEqual([
+      '@acme/tinkerise-enhancement-y',
+      '@acme/tinkerise-scaffolder-x',
+    ])
+  })
+
+  it('ignores presets and unrelated packages', async () => {
+    await writePkg({
+      dependencies: { 'tinkerise-preset-saas': '^1.0.0', 'express': '^4' },
+    })
+
+    expect(await discoverNpmSources(dir)).toEqual([])
+  })
+
+  it('returns an empty list when package.json is missing', async () => {
+    expect(await discoverNpmSources(dir)).toEqual([])
+  })
+})


### PR DESCRIPTION
Third Tier C step — visibility into installed external sources, still listing-only (no load/execute, no consent needed).

### What it does
- **`@tinkerise/core` — `discoverNpmSources(projectDir)`**: offline scan of `package.json` (deps + devDeps) for `tinkerise-scaffolder-*` / `tinkerise-enhancement-*` (incl. scoped), mirroring `discoverNpmPresets`. Side-effect-free.
- **`tinkerise trust list`** now shows two sections: **Trusted sources** and **Installed, not trusted** (discovered packages not yet trusted, hinting `trust add`). Already-trusted discovered packages aren't duplicated.

### Tests (test-first) + smoke
- core: finds scaffolder+enhancement in deps/devDeps, scoped packages, ignores presets/unrelated, empty when no package.json.
- cli: `trust list` shows installed-but-untrusted; trusted discovered packages aren't listed as untrusted.
- Built-CLI smoke (project with `tinkerise-enhancement-biome`): before `trust add` it shows under "Installed, not trusted"; after, under "Trusted sources."

Full gate green locally: lint, typecheck, test (94 + 682 + 483), build. Changeset included (`@tinkerise/cli` + `@tinkerise/core` minor).