### PR TITLE
feat: consent-gated external npm enhancements (Tier C)

### DIFF
--- a/.changeset/tier3-external-enhancements.md
+++ b/.changeset/tier3-external-enhancements.md
@@ -1,0 +1,6 @@
+---
+"@tinkerise/cli": minor
+"@tinkerise/core": minor
+---
+
+`tinkerise add npm:<package>` can now install an external `tinkerise-enhancement-*` package, gated by explicit per-source consent. Adds `loadNpmEnhancement` (imports + strictly validates an external EnhancementModule). Running an untrusted source prompts an explicit warning (defaults to No) and remembers the decision; in CI an untrusted source errors with `tinkerise trust add <source>` first (pre-trust required) so third-party code never runs non-interactively without prior consent. Only npm enhancements are supported for now; `github:` sources are rejected.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,7 +15,11 @@ import {
   buildProjectContext,
   ENHANCEMENT_NEXT_STEPS,
   enhancementRegistry,
+  ensureSourceTrusted,
   isCI,
+  isSourceTrusted,
+  loadNpmEnhancement,
+  parseSource,
   runEnhancements,
   showEnhancementSummary,
   showPerEnhancementSummary,
@@ -30,6 +34,60 @@ export interface AddOptions {
   verbose?: boolean
   /** Re-apply the enhancements recorded in tinkerise.lock */
   fromLock?: boolean
+}
+
+/** Source specs (npm:/github:) are external; bare names are built-in enhancement ids. */
+const EXTERNAL_SOURCE_RE = /^(?:npm|github):/
+
+/** Interactive per-source consent: explicit warning, defaults to No. */
+async function promptSourceConsent({ id }: { id: string }): Promise<boolean> {
+  if (isCI)
+    return false // defense-in-depth: never auto-consent non-interactively
+  p.log.warn(`'${id}' is an external source. Trusting it runs third-party code on your machine.`)
+  const result = await p.confirm({ message: `Trust and run ${id}?`, initialValue: false })
+  if (p.isCancel(result)) {
+    p.cancel('Cancelled.')
+    process.exit(0)
+  }
+  return result === true
+}
+
+/**
+ * Resolve an external source spec to an EnhancementModule, gated by per-source
+ * consent. Returns null when consent is declined interactively. In CI an
+ * untrusted source errors (pre-trust required) — third-party code never runs
+ * non-interactively without a prior explicit trust decision.
+ */
+async function resolveExternalEnhancement(spec: string): Promise<EnhancementModule | null> {
+  const { kind, id } = parseSource(spec)
+  if (kind !== 'npm') {
+    throw new TinkeriseError({
+      message: `${kind} sources are not supported yet.`,
+      code: 'SOURCE_KIND_UNSUPPORTED',
+      suggestion: 'Use an npm enhancement: tinkerise add npm:tinkerise-enhancement-<name>',
+    })
+  }
+  if (isCI && !(await isSourceTrusted(id))) {
+    throw new TinkeriseError({
+      message: `External source '${id}' is not trusted.`,
+      code: 'SOURCE_NOT_TRUSTED',
+      suggestion: `Run: tinkerise trust add ${id}`,
+    })
+  }
+  if (!(await ensureSourceTrusted(id, promptSourceConsent))) {
+    p.log.info(`Skipped ${id} (not trusted).`)
+    return null
+  }
+  const packageName = id.slice('npm:'.length)
+  const mod = await loadNpmEnhancement(packageName)
+  if (!mod) {
+    throw new TinkeriseError({
+      message: `Could not load an enhancement from '${id}'.`,
+      code: 'SOURCE_LOAD_FAILED',
+      suggestion: `Ensure ${packageName} is installed and exports a tinkerise enhancement.`,
+    })
+  }
+  return mod
 }
 
 /**
@@ -102,14 +160,22 @@ export async function runAddCommand(
       return
   }
   else {
-    // Direct: resolve names to modules
-    modules = names.map((name) => {
-      const mod = enhancementRegistry.get(name)
-      if (!mod) {
-        throw new UnknownEnhancementError(name, allEnhancementModules.map(m => m.id))
+    // Direct: resolve names to modules (built-in ids + external npm sources)
+    modules = []
+    for (const name of names) {
+      if (EXTERNAL_SOURCE_RE.test(name)) {
+        const mod = await resolveExternalEnhancement(name)
+        if (mod)
+          modules.push(mod)
       }
-      return mod
-    })
+      else {
+        const mod = enhancementRegistry.get(name)
+        if (!mod) {
+          throw new UnknownEnhancementError(name, allEnhancementModules.map(m => m.id))
+        }
+        modules.push(mod)
+      }
+    }
   }
 
   // 3. Run enhancement pipeline

--- a/packages/cli/tests/commands/add.test.ts
+++ b/packages/cli/tests/commands/add.test.ts
@@ -31,6 +31,9 @@ const mockPLogInfo = vi.hoisted(() => vi.fn())
 const mockPLogWarn = vi.hoisted(() => vi.fn())
 const mockRecordEnhancements = vi.hoisted(() => vi.fn())
 const mockReadLockFile = vi.hoisted(() => vi.fn())
+const mockIsSourceTrusted = vi.hoisted(() => vi.fn())
+const mockEnsureSourceTrusted = vi.hoisted(() => vi.fn())
+const mockLoadNpmEnhancement = vi.hoisted(() => vi.fn())
 
 vi.mock('@tinkerise/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tinkerise/core')>()
@@ -44,6 +47,9 @@ vi.mock('@tinkerise/core', async (importOriginal) => {
     allEnhancementModules: mockAllEnhancementModules,
     get isCI() { return mockIsCI.value },
     ENHANCEMENT_NEXT_STEPS: mockEnhancementNextSteps,
+    isSourceTrusted: mockIsSourceTrusted,
+    ensureSourceTrusted: mockEnsureSourceTrusted,
+    loadNpmEnhancement: mockLoadNpmEnhancement,
   }
 })
 
@@ -275,6 +281,43 @@ describe('runAddCommand', () => {
 
     await expect(runAddCommand([], { fromLock: true })).rejects.toThrow(/tinkerise\.lock/i)
     expect(mockRunEnhancements).not.toHaveBeenCalled()
+  })
+
+  it('loads and runs a trusted external npm enhancement', async () => {
+    const extMod = { id: 'biome', name: 'Biome', description: 'd', dependsOn: [], detect: vi.fn(), install: vi.fn() }
+    mockEnsureSourceTrusted.mockResolvedValue(true)
+    mockLoadNpmEnhancement.mockResolvedValue(extMod)
+    mockRunEnhancements.mockResolvedValue({ installed: ['biome'], skipped: [], failed: [], notRun: [], results: new Map() })
+
+    await runAddCommand(['npm:tinkerise-enhancement-biome'], {})
+
+    expect(mockEnsureSourceTrusted).toHaveBeenCalledWith('npm:tinkerise-enhancement-biome', expect.any(Function))
+    expect(mockLoadNpmEnhancement).toHaveBeenCalledWith('tinkerise-enhancement-biome')
+    expect(mockRunEnhancements).toHaveBeenCalledWith(
+      expect.objectContaining({ modules: expect.arrayContaining([extMod]) }),
+    )
+  })
+
+  it('errors for an untrusted external source in CI (require pre-trust)', async () => {
+    mockIsCI.value = true
+    mockIsSourceTrusted.mockResolvedValue(false)
+
+    await expect(runAddCommand(['npm:tinkerise-enhancement-biome'], {})).rejects.toThrow(/not trusted/i)
+    expect(mockLoadNpmEnhancement).not.toHaveBeenCalled()
+  })
+
+  it('skips an external source when consent is declined', async () => {
+    mockEnsureSourceTrusted.mockResolvedValue(false)
+    mockRunEnhancements.mockResolvedValue({ installed: [], skipped: [], failed: [], notRun: [], results: new Map() })
+
+    await runAddCommand(['npm:tinkerise-enhancement-biome'], {})
+
+    expect(mockLoadNpmEnhancement).not.toHaveBeenCalled()
+    expect(mockRunEnhancements).toHaveBeenCalledWith(expect.objectContaining({ modules: [] }))
+  })
+
+  it('rejects github sources (npm enhancements only for now)', async () => {
+    await expect(runAddCommand(['github:acme/widgets'], {})).rejects.toThrow(/not supported|not yet/i)
   })
 
   it('passes verbose option to buildProjectContext', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,12 +183,13 @@ export {
   getTrustStorePath,
   isSourceTrusted,
   listTrustedSources,
+  loadNpmEnhancement,
   parseSource,
   TRUST_STORE_FILENAME,
   trustSource,
   untrustSource,
 } from './sources/index.js'
-export type { OnSourceConsent, ResolvedSource, SourceConsentRequest, SourceKind } from './sources/index.js'
+export type { ModuleImporter, OnSourceConsent, ResolvedSource, SourceConsentRequest, SourceKind } from './sources/index.js'
 
 /**
  * Templates — utility project generators (MCP server, CLI tool, npm library).

--- a/packages/core/src/sources/index.ts
+++ b/packages/core/src/sources/index.ts
@@ -1,3 +1,4 @@
 export * from './discovery.js'
+export * from './load.js'
 export * from './resolve.js'
 export * from './trust-store.js'

--- a/packages/core/src/sources/load.ts
+++ b/packages/core/src/sources/load.ts
@@ -1,0 +1,43 @@
+/**
+ * External enhancement loader (Tier C) — import a `tinkerise-enhancement-*`
+ * package and validate it exposes a well-formed EnhancementModule.
+ *
+ * SECURITY: importing a package executes its module-load code, so callers MUST
+ * gate this behind explicit per-source consent (`ensureSourceTrusted`). The
+ * importer is injectable for testing.
+ */
+
+import type { EnhancementModule } from '../enhancements/index.js'
+
+export type ModuleImporter = (specifier: string) => Promise<unknown>
+
+/** Strictly validate the full EnhancementModule contract before trusting the cast. */
+function isEnhancementModule(value: unknown): value is EnhancementModule {
+  if (typeof value !== 'object' || value === null)
+    return false
+  const m = value as Record<string, unknown>
+  return typeof m.id === 'string'
+    && typeof m.name === 'string'
+    && typeof m.description === 'string'
+    && Array.isArray(m.dependsOn)
+    && typeof m.detect === 'function'
+    && typeof m.install === 'function'
+}
+
+/**
+ * Load and validate an enhancement module from an npm package. Returns null if
+ * the import fails or the export is not a well-formed EnhancementModule.
+ */
+export async function loadNpmEnhancement(
+  packageName: string,
+  importModule: ModuleImporter = specifier => import(specifier),
+): Promise<EnhancementModule | null> {
+  try {
+    const mod = await importModule(packageName) as Record<string, unknown>
+    const candidate = (mod && typeof mod === 'object' && 'default' in mod) ? mod.default : mod
+    return isEnhancementModule(candidate) ? candidate : null
+  }
+  catch {
+    return null
+  }
+}

--- a/packages/core/tests/sources/load.test.ts
+++ b/packages/core/tests/sources/load.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadNpmEnhancement } from '../../src/sources/load'
+
+function validModule() {
+  return {
+    id: 'biome',
+    name: 'Biome',
+    description: 'Biome linter/formatter',
+    dependsOn: [],
+    detect: async () => ({ installed: false, configFiles: [], partial: false }),
+    install: async () => ({ success: true, filesModified: [], packagesAdded: [], warnings: [] }),
+  }
+}
+
+describe('loadNpmEnhancement', () => {
+  it('loads a module exposed as a default export', async () => {
+    const mod = validModule()
+    const importer = vi.fn(async () => ({ default: mod }))
+
+    const loaded = await loadNpmEnhancement('tinkerise-enhancement-biome', importer)
+
+    expect(importer).toHaveBeenCalledWith('tinkerise-enhancement-biome')
+    expect(loaded?.id).toBe('biome')
+  })
+
+  it('loads a module exposed as named exports (no default)', async () => {
+    const loaded = await loadNpmEnhancement('pkg', async () => validModule())
+    expect(loaded?.id).toBe('biome')
+  })
+
+  it('returns null when the export is missing required fields', async () => {
+    const loaded = await loadNpmEnhancement('pkg', async () => ({ default: { id: 'x', name: 'X' } }))
+    expect(loaded).toBeNull()
+  })
+
+  it('returns null when detect/install are not functions', async () => {
+    const loaded = await loadNpmEnhancement('pkg', async () => ({
+      default: { id: 'x', name: 'X', description: 'd', dependsOn: [], detect: 'nope', install: 'nope' },
+    }))
+    expect(loaded).toBeNull()
+  })
+
+  it('returns null when the import throws', async () => {
+    const loaded = await loadNpmEnhancement('pkg', async () => {
+      throw new Error('not installed')
+    })
+    expect(loaded).toBeNull()
+  })
+})


### PR DESCRIPTION
## Tier C headline — consent-gated external npm enhancements

`tinkerise add npm:tinkerise-enhancement-<name>` installs an external enhancement, **gated by explicit per-source consent** (design confirmed with the maintainer). This is the first path that runs third-party code, so the load primitive ships together with its consent gate.

### Behavior (per confirmed design)
- **Interactive, untrusted source** → explicit warning that it runs third-party code on your machine + a confirm that **defaults to No**; granting it persists trust (remembered next time).
- **CI / non-interactive, untrusted** → errors `SOURCE_NOT_TRUSTED` with `tinkerise trust add <source>` — third-party code never auto-runs without a prior explicit trust decision (pre-trust required).
- **Declined** → the source is skipped (other args still proceed).
- **Scope**: npm enhancements only; `github:` sources are rejected with `SOURCE_KIND_UNSUPPORTED`.

### Implementation
- **`@tinkerise/core` `loadNpmEnhancement(pkg, importer?)`**: dynamically imports the package and **strictly validates** the full `EnhancementModule` contract before use; returns null on import failure or malformed export. Importer is injectable for tests. SECURITY note in code: import executes module-load code, so callers must gate via `ensureSourceTrusted`.
- **`add.ts`**: routes `npm:`/`github:` args through `resolveExternalEnhancement` (parse → CI pre-trust check → `ensureSourceTrusted(promptSourceConsent)` → load), then runs them through the normal enhancement pipeline. Built-in ids are unchanged.

### Tests (test-first) + smoke
- core: loads default/named export, rejects malformed (missing fields, non-function detect/install), import-throws → null.
- cli: trusted → loads + runs; CI+untrusted → `SOURCE_NOT_TRUSTED`; declined → skipped (empty modules); `github:` → rejected.
- Built-CLI smoke confirmed both error paths render cleanly.

Full gate green: lint, typecheck, test (94 + 687 + 487), build. Changeset (`@tinkerise/cli` + `@tinkerise/core` minor).

> Follow-up (noted, not in this PR): record external-source provenance in `tinkerise.lock` so `--from-lock` can reproduce external enhancements; docs for the trusted-sources workflow.
