### PR TITLE
docs: surface the stack builder in README and getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ tinkerise is a unified CLI that wraps official framework scaffolders instead of 
 ## Deep dive in docs
 
 - Getting started: [https://farce1.github.io/tinkerise/guides/getting-started/](https://farce1.github.io/tinkerise/guides/getting-started/)
+- Stack builder (pick a stack, copy the command): [https://farce1.github.io/tinkerise/guides/stack-builder/](https://farce1.github.io/tinkerise/guides/stack-builder/)
 - Scaffolder guides: [https://farce1.github.io/tinkerise/guides/scaffolders/](https://farce1.github.io/tinkerise/guides/scaffolders/)
 - Enhancement guides: [https://farce1.github.io/tinkerise/guides/enhancements/](https://farce1.github.io/tinkerise/guides/enhancements/)
 - Reproducible projects: [https://farce1.github.io/tinkerise/guides/reproducible-projects/](https://farce1.github.io/tinkerise/guides/reproducible-projects/)

--- a/apps/docs/src/content/docs/guides/getting-started.mdx
+++ b/apps/docs/src/content/docs/guides/getting-started.mdx
@@ -115,6 +115,7 @@ tinkerise add prettier husky
 
 ## 7) Where to go next
 
+- Build a command visually with the [Stack Builder](/tinkerise/guides/stack-builder/)
 - Browse framework guides in [`/guides/scaffolders/`](/tinkerise/guides/scaffolders/)
 - Explore enhancement modules in [`/guides/enhancements/`](/tinkerise/guides/enhancements/)
 - Recreate a stack anywhere with [Reproducible Projects](/tinkerise/guides/reproducible-projects/)


### PR DESCRIPTION
## Summary

The interactive Stack Builder shipped in #58 but was only reachable from the docs sidebar. This
links it from the two places new users actually land, so the flagship feature is discoverable.

- **README** → added to the "Deep dive in docs" list (right after Getting started).
- **getting-started** → added to the "Where to go next" list.

Mirrors the established pattern from #51 (surfacing reproducible projects in the README and getting
started).

## Test plan

- Docs build green with no broken-link warnings; `getting-started` re-rendered.
- Lint ✅. Docs-only change — no published package affected, so no changeset.