### PR TITLE
feat: export tinkerise.lock from the stack builder

### DIFF
--- a/.changeset/stack-builder-lock-export.md
+++ b/.changeset/stack-builder-lock-export.md
@@ -1,0 +1,7 @@
+---
+"@tinkerise/shared": minor
+---
+
+Add `buildStackLock` to `@tinkerise/shared/stack` — a pure serializer that turns a stack selection
+into a schema-valid `tinkerise.lock`. Powers the new "Reproducible lock" export in the docs stack
+builder.

--- a/apps/docs/src/components/stack-builder.astro
+++ b/apps/docs/src/components/stack-builder.astro
@@ -2,7 +2,11 @@
 // Build-time: read the framework/flag/enhancement vocabulary straight from the
 // frozen registry so the builder never drifts from the CLI.
 import { enhancementRegistry, getAllScaffolders, SCAFFOLD_FLAG_NAMES } from '@tinkerise/core'
-import { SAFE_NAME_REGEX, SAFE_NAME_RULES } from '@tinkerise/shared'
+import { SAFE_NAME_REGEX, SAFE_NAME_RULES, VERSION } from '@tinkerise/shared'
+
+// Package managers the lock can record (PackageManager is a type, so the runtime
+// list is mirrored here — a stable, rarely-changing set).
+const PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun']
 
 interface FrameworkVocab {
   name: string
@@ -32,7 +36,7 @@ const categories = [...new Set(frameworks.map(f => f.category))]
 // Single-source the project-name pattern from the CLI's validator (zod stays at
 // build time; the regex source travels to the client for live validation).
 const namePattern = SAFE_NAME_REGEX.source
-const vocab = { frameworks, enhancements, namePattern }
+const vocab = { frameworks, enhancements, namePattern, version: VERSION }
 ---
 
 <div class="stack-builder" data-vocab={JSON.stringify(vocab)}>
@@ -83,21 +87,41 @@ const vocab = { frameworks, enhancements, namePattern }
   <div class="sb-field">
     <span class="sb-legend">Command</span>
     <pre class="sb-output"><code id="sb-output"></code></pre>
-    <button id="sb-copy" type="button">Copy</button>
+    <button id="sb-copy" class="sb-copy" type="button">Copy</button>
+  </div>
+
+  <div class="sb-field">
+    <span class="sb-legend">Reproducible lock</span>
+    <label class="sb-pm">
+      Package manager
+      <select id="sb-pm">
+        {PACKAGE_MANAGERS.map(pm => <option value={pm}>{pm}</option>)}
+      </select>
+    </label>
+    <details>
+      <summary>Preview tinkerise.lock</summary>
+      <pre class="sb-output"><code id="sb-lock-output"></code></pre>
+    </details>
+    <button id="sb-lock-copy" class="sb-copy" type="button">Copy tinkerise.lock</button>
+    <p class="sb-hint">
+      Save as <code>tinkerise.lock</code>, then run <code>tinkerise &lt;name&gt; --from-lock</code>.
+      Vite and T3 also need an interactive variant, so scaffold those directly.
+    </p>
   </div>
 </div>
 
 <script>
-  import { buildStackCommand } from '@tinkerise/shared/stack'
+  import { buildStackCommand, buildStackLock } from '@tinkerise/shared/stack'
 
   interface FrameworkVocab { name: string, category: string, flags: string[] }
 
   const root = document.querySelector<HTMLDivElement>('.stack-builder')
   if (root) {
-    const vocab = JSON.parse(root.dataset.vocab ?? '{"frameworks":[],"enhancements":[],"namePattern":".*"}') as {
+    const vocab = JSON.parse(root.dataset.vocab ?? '{"frameworks":[],"enhancements":[],"namePattern":".*","version":"0.0.0"}') as {
       frameworks: FrameworkVocab[]
       enhancements: string[]
       namePattern: string
+      version: string
     }
     const nameRegex = new RegExp(vocab.namePattern)
 
@@ -106,11 +130,28 @@ const vocab = { frameworks, enhancements, namePattern }
     const frameworkSelect = root.querySelector<HTMLSelectElement>('#sb-framework')!
     const flagsContainer = root.querySelector<HTMLDivElement>('#sb-flags')!
     const enhancementsContainer = root.querySelector<HTMLDivElement>('#sb-enhancements')!
+    const pmSelect = root.querySelector<HTMLSelectElement>('#sb-pm')!
     const output = root.querySelector<HTMLElement>('#sb-output')!
-    const copyButton = root.querySelector<HTMLButtonElement>('#sb-copy')!
+    const lockOutput = root.querySelector<HTMLElement>('#sb-lock-output')!
 
     function selectedFramework(): FrameworkVocab | undefined {
       return vocab.frameworks.find(f => f.name === frameworkSelect.value)
+    }
+
+    /** Copy getText()'s value on click, with transient button feedback. */
+    function wireCopy(id: string, getText: () => string) {
+      const button = root!.querySelector<HTMLButtonElement>(id)!
+      const label = button.textContent
+      button.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(getText())
+          button.textContent = 'Copied!'
+        }
+        catch {
+          button.textContent = 'Copy failed'
+        }
+        setTimeout(() => { button.textContent = label }, 1500)
+      })
     }
 
     function renderFlags() {
@@ -133,39 +174,40 @@ const vocab = { frameworks, enhancements, namePattern }
       const framework = selectedFramework()
       if (!framework) {
         output.textContent = ''
+        lockOutput.textContent = ''
         return
       }
+      const flags = checkedValues(flagsContainer, 'data-flag')
+      const enhancements = checkedValues(enhancementsContainer, 'data-enhancement')
+      const category = framework.category as any
+
+      // Command (name-dependent): clear it and flag the input when the name is invalid.
       const name = nameInput.value.trim()
       const nameInvalid = name !== '' && !nameRegex.test(name)
       nameError.hidden = !nameInvalid
       nameInput.setAttribute('aria-invalid', String(nameInvalid))
       if (nameInvalid) {
         output.textContent = ''
-        return
       }
-      const command = buildStackCommand({
-        framework: framework.name,
-        category: framework.category as any,
-        name: name || undefined,
-        flags: checkedValues(flagsContainer, 'data-flag'),
-        enhancements: checkedValues(enhancementsContainer, 'data-enhancement'),
-      })
-      output.textContent = command.add ? `${command.scaffold}\n${command.add}` : command.scaffold
+      else {
+        const command = buildStackCommand({ framework: framework.name, category, name: name || undefined, flags, enhancements })
+        output.textContent = command.add ? `${command.scaffold}\n${command.add}` : command.scaffold
+      }
+
+      // Lock (name-independent): a tinkerise.lock records no project name.
+      const lock = buildStackLock(
+        { framework: framework.name, category, flags, enhancements },
+        { version: vocab.version, packageManager: pmSelect.value },
+      )
+      lockOutput.textContent = JSON.stringify(lock, null, 2)
     }
 
-    copyButton.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(output.textContent ?? '')
-        copyButton.textContent = 'Copied!'
-      }
-      catch {
-        copyButton.textContent = 'Copy failed'
-      }
-      setTimeout(() => { copyButton.textContent = 'Copy' }, 1500)
-    })
+    wireCopy('#sb-copy', () => output.textContent ?? '')
+    wireCopy('#sb-lock-copy', () => lockOutput.textContent ?? '')
 
     nameInput.addEventListener('input', render)
     frameworkSelect.addEventListener('change', () => { renderFlags(); render() })
+    pmSelect.addEventListener('change', render)
     enhancementsContainer.querySelectorAll('input').forEach(el => el.addEventListener('change', render))
 
     renderFlags()
@@ -223,7 +265,18 @@ const vocab = { frameworks, enhancements, namePattern }
   .sb-output {
     margin: 0;
   }
-  #sb-copy {
+  .sb-pm {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 400;
+  }
+  .sb-hint {
+    margin: 0;
+    font-size: 0.85em;
+    color: var(--sl-color-gray-3);
+  }
+  .sb-copy {
     align-self: flex-start;
     padding: 0.4rem 0.9rem;
     border: 1px solid var(--sl-color-accent);
@@ -233,7 +286,7 @@ const vocab = { frameworks, enhancements, namePattern }
     cursor: pointer;
     font: inherit;
   }
-  #sb-copy:hover {
+  .sb-copy:hover {
     background: var(--sl-color-accent);
   }
 </style>

--- a/packages/shared/src/stack/serialize.ts
+++ b/packages/shared/src/stack/serialize.ts
@@ -4,6 +4,7 @@
  * client-side in the docs-site stack builder.
  */
 import type { ScaffolderCategory } from '../index.js'
+import type { TinkeriseLock } from '../lock/index.js'
 
 export interface StackSelection {
   framework: string
@@ -41,4 +42,31 @@ export function buildStackCommand(selection: StackSelection, programName = 'tink
     result.add = `${programName} add ${enhancements.join(' ')}`
 
   return result
+}
+
+export interface StackLockOptions {
+  /** tinkerise version recorded as createdWith */
+  version: string
+  packageManager: string
+}
+
+/**
+ * Build a reproducible tinkerise.lock from a stack selection. schemaVersion is
+ * pinned to 1 — the TinkeriseLock literal type makes any LOCK_SCHEMA_VERSION bump
+ * a compile error here, so it cannot silently drift.
+ */
+export function buildStackLock(selection: StackSelection, opts: StackLockOptions): TinkeriseLock {
+  const flags: Record<string, boolean> = {}
+  for (const flag of selection.flags ?? [])
+    flags[flag] = true
+
+  return {
+    schemaVersion: 1,
+    framework: selection.framework,
+    category: selection.category,
+    flags,
+    enhancements: (selection.enhancements ?? []).map(id => ({ id, version: null })),
+    packageManager: opts.packageManager,
+    createdWith: opts.version,
+  }
 }

--- a/packages/shared/tests/stack/serialize.test.ts
+++ b/packages/shared/tests/stack/serialize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { buildStackCommand } from '../../src/stack/serialize.js'
+import { TinkeriseLockSchema } from '../../src/lock/schema.js'
+import { buildStackCommand, buildStackLock } from '../../src/stack/serialize.js'
 
 describe('buildStackCommand', () => {
   it('builds a positional scaffold command with flags', () => {
@@ -38,5 +39,33 @@ describe('buildStackCommand', () => {
     )
     expect(cmd.scaffold).toBe('tk web next app')
     expect(cmd.add).toBe('tk add eslint')
+  })
+})
+
+describe('buildStackLock', () => {
+  const opts = { version: '1.2.3', packageManager: 'pnpm' }
+
+  it('builds a schema-valid lock with mapped flags and enhancements', () => {
+    const lock = buildStackLock(
+      { framework: 'next', category: 'web', flags: ['typescript', 'tailwind'], enhancements: ['eslint', 'prettier'] },
+      opts,
+    )
+    expect(TinkeriseLockSchema.safeParse(lock).success).toBe(true)
+    expect(lock.framework).toBe('next')
+    expect(lock.category).toBe('web')
+    expect(lock.flags).toEqual({ typescript: true, tailwind: true })
+    expect(lock.enhancements).toEqual([
+      { id: 'eslint', version: null },
+      { id: 'prettier', version: null },
+    ])
+    expect(lock.packageManager).toBe('pnpm')
+    expect(lock.createdWith).toBe('1.2.3')
+  })
+
+  it('produces empty flags and enhancements when none are selected', () => {
+    const lock = buildStackLock({ framework: 'go', category: 'backend' }, opts)
+    expect(TinkeriseLockSchema.safeParse(lock).success).toBe(true)
+    expect(lock.flags).toEqual({})
+    expect(lock.enhancements).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Extends the Tier D stack builder to emit a reusable **`tinkerise.lock`** (the roadmap's "shareable
preset/lock" output), so a configured stack can be reproduced with the existing
`tinkerise <name> --from-lock`.

## What's in it

- **`@tinkerise/shared/stack`: `buildStackLock`** — a pure serializer that turns a stack selection
  into a schema-valid `tinkerise.lock` (flags → record, enhancements → `{id, version:null}`).
  `schemaVersion` is typecheck-pinned via the `TinkeriseLock` literal type so it can't drift from
  `LOCK_SCHEMA_VERSION`. Stays in the zod-free `/stack` subpath (entry is 161B).
- **Docs builder** — new "Reproducible lock" section: a package-manager selector, a live
  `tinkerise.lock` preview, and a copy button. A shared DRY copy helper now backs both copy buttons.

## Viability / boundaries

- The generated lock validates against the real `TinkeriseLockSchema` (asserted in the unit test),
  so `--from-lock` accepts it.
- Vite and T3 require an interactive `variant` the builder can't capture; the UI notes that those
  must be scaffolded directly (and the CLI already errors clearly via `LOCK_MISSING_VARIANT`).

## Test plan

- `buildStackLock`: 2 unit tests (schema-valid output + field mapping; empty flags/enhancements),
  validating against `TinkeriseLockSchema`.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ · build ✅ · docs build ✅.
- Playwright smoke against the built site: configuring next + typescript + eslint + pnpm yields a
  valid lock, the copy button writes the lock JSON to the clipboard, **no console errors**.