### PR TITLE
docs: document the stack builder's reproducible-lock export

### DIFF
--- a/apps/docs/src/content/docs/guides/stack-builder.mdx
+++ b/apps/docs/src/content/docs/guides/stack-builder.mdx
@@ -24,3 +24,10 @@ The framework, flag, and enhancement options come straight from tinkerise's buil
 they always match the version of the CLI these docs were built against. Run
 [`tinkerise list`](/tinkerise/reference/commands/) to see the same catalog from your terminal, or
 add `--dry-run` to any command to preview it before running.
+
+## Export a reproducible lock
+
+The **Reproducible lock** section builds a [`tinkerise.lock`](/tinkerise/guides/reproducible-projects/)
+for your selection. Pick a package manager, copy the lock into a `tinkerise.lock` file, then run
+`tinkerise <name> --from-lock` to recreate the same stack anywhere. Vite and T3 need an interactive
+variant the builder can't capture, so scaffold those directly.


### PR DESCRIPTION
## Summary

Follow-up to #61. The lock-export UI shipped, but the Stack Builder guide only described the command
output. This adds an "Export a reproducible lock" section documenting the package-manager selector,
the copy-to-`tinkerise.lock` workflow with `tinkerise <name> --from-lock`, and the Vite/T3 caveat.

## Test plan

- Docs build green with no broken-link warnings (the link to the reproducible-projects guide
  resolves). Lint ✅. Docs-only — no published package affected, so no changeset.