### PR TITLE
fix(core): validate project name & PM in cli/lib/mcp template generators

### DIFF
--- a/.changeset/validate-template-input.md
+++ b/.changeset/validate-template-input.md
@@ -1,0 +1,10 @@
+---
+"@tinkerise/core": patch
+---
+
+Harden the `cli`, `lib`, and `mcp` template generators: validate the project name and package
+manager before any filesystem work. Previously these commands passed the name straight to
+`mkdir`/generated files with no validation, allowing path traversal (`tinkerise cli ../foo`),
+invalid npm names, and an unknown `--package-manager` that surfaced as an "unexpected runtime
+failure". They now reject such input with a structured `ConfigValidationError`, matching the
+scaffold and preset paths.

--- a/packages/core/src/templates/cli-tool.ts
+++ b/packages/core/src/templates/cli-tool.ts
@@ -7,7 +7,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a complete CLI tool project.
@@ -17,6 +17,7 @@ import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
  */
 export async function generateCliTool(name: string, options: TemplateOptions = {}): Promise<void> {
   const pm = options.packageManager ?? 'npm'
+  assertValidTemplateInput(name, pm)
   const projectDir = name
 
   // 1. Create project directory

--- a/packages/core/src/templates/lib.ts
+++ b/packages/core/src/templates/lib.ts
@@ -7,7 +7,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a publish-ready npm library project.
@@ -17,6 +17,7 @@ import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
  */
 export async function generateLib(name: string, options: TemplateOptions = {}): Promise<void> {
   const pm = options.packageManager ?? 'npm'
+  assertValidTemplateInput(name, pm)
   const projectDir = name
 
   // 1. Create project directory

--- a/packages/core/src/templates/mcp.ts
+++ b/packages/core/src/templates/mcp.ts
@@ -9,7 +9,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a complete MCP server project.
@@ -19,6 +19,7 @@ import { printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
  */
 export async function generateMcpServer(name: string, options: TemplateOptions = {}): Promise<void> {
   const pm = options.packageManager ?? 'npm'
+  assertValidTemplateInput(name, pm)
   const projectDir = name
 
   // 1. Create project directory

--- a/packages/core/src/templates/shared.ts
+++ b/packages/core/src/templates/shared.ts
@@ -8,8 +8,27 @@
 
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
+import { ProjectNameSchema } from '@tinkerise/shared'
 import { execa } from 'execa'
 import pc from 'picocolors'
+import { ConfigValidationError } from '../errors/base.js'
+
+/** Package managers a template install can run (mirrors the PackageManager union). */
+const VALID_PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun']
+
+/**
+ * Validate template generator input before any filesystem work. Mirrors the
+ * scaffold path: rejects unsafe/invalid project names (blocking path traversal
+ * and invalid npm names) and unknown package managers, with structured errors.
+ */
+export function assertValidTemplateInput(name: string, packageManager: string): void {
+  if (!ProjectNameSchema.safeParse(name).success) {
+    throw new ConfigValidationError('projectName', name, 'lowercase letters, numbers, hyphens, dots, underscores; max 64 chars')
+  }
+  if (!VALID_PACKAGE_MANAGERS.includes(packageManager)) {
+    throw new ConfigValidationError('packageManager', packageManager, VALID_PACKAGE_MANAGERS.join(', '))
+  }
+}
 
 /**
  * Write a file into the project directory, creating intermediate directories as needed.

--- a/packages/core/tests/templates/cli-tool.test.ts
+++ b/packages/core/tests/templates/cli-tool.test.ts
@@ -12,6 +12,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConfigValidationError } from '../../src/errors/base.js'
 import { generateCliTool } from '../../src/templates/cli-tool.js'
 
 // Hoist mocks for vi.mock factories
@@ -42,6 +43,17 @@ describe('generateCliTool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('rejects an invalid project name before touching the filesystem', async () => {
+    await expect(generateCliTool('../escape')).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown package manager', async () => {
+    await expect(generateCliTool('my-tool', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { path, content } pairs */

--- a/packages/core/tests/templates/lib.test.ts
+++ b/packages/core/tests/templates/lib.test.ts
@@ -14,6 +14,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConfigValidationError } from '../../src/errors/base.js'
 import { generateLib } from '../../src/templates/lib.js'
 
 // Hoist mocks for vi.mock factories
@@ -44,6 +45,17 @@ describe('generateLib', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('rejects an invalid project name before touching the filesystem', async () => {
+    await expect(generateLib('../escape')).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown package manager', async () => {
+    await expect(generateLib('my-lib', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { path, content } pairs */

--- a/packages/core/tests/templates/mcp.test.ts
+++ b/packages/core/tests/templates/mcp.test.ts
@@ -14,6 +14,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConfigValidationError } from '../../src/errors/base.js'
 import { generateMcpServer } from '../../src/templates/mcp.js'
 
 // Hoist mocks for vi.mock factories
@@ -44,6 +45,17 @@ describe('generateMcpServer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('rejects an invalid project name before touching the filesystem', async () => {
+    await expect(generateMcpServer('../escape')).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown package manager', async () => {
+    await expect(generateMcpServer('my-server', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
+    expect(mockMkdir).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { filename, content } pairs */

--- a/packages/core/tests/templates/shared.test.ts
+++ b/packages/core/tests/templates/shared.test.ts
@@ -13,7 +13,8 @@
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { printTemplateSummary, runInstall, writeProjectFile } from '../../src/templates/shared.js'
+import { ConfigValidationError } from '../../src/errors/base.js'
+import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from '../../src/templates/shared.js'
 
 const PROJECT_ROOT = join('/', 'tmp', 'project')
 const projectPath = (relativePath: string) => join(PROJECT_ROOT, ...relativePath.split('/'))
@@ -159,6 +160,28 @@ describe('shared template utilities', () => {
 
       const output = consoleSpy.mock.calls.map(c => c[0]).join('\n')
       expect(output).toContain('cd cool-project')
+    })
+  })
+
+  describe('assertValidTemplateInput', () => {
+    it('accepts a valid name and package manager', () => {
+      expect(() => assertValidTemplateInput('my-tool', 'pnpm')).not.toThrow()
+    })
+
+    it('rejects path-traversal and otherwise invalid project names', () => {
+      for (const bad of ['../foo', '/tmp/x', 'Bad Name', '@scope/x', '.hidden']) {
+        expect(() => assertValidTemplateInput(bad, 'npm')).toThrow(ConfigValidationError)
+      }
+    })
+
+    it('rejects an unknown package manager', () => {
+      expect(() => assertValidTemplateInput('my-tool', 'bogus')).toThrow(ConfigValidationError)
+      try {
+        assertValidTemplateInput('my-tool', 'bogus')
+      }
+      catch (err) {
+        expect((err as ConfigValidationError).code).toBe('CONFIG_VALIDATION')
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Quality/hardening pass finding (via a focused audit): the `cli`, `lib`, and `mcp` template
generators were the lone commands that **bypassed the project-name validation** the rest of the CLI
enforces. They passed `name` straight to `mkdir(name, { recursive: true })` and into generated
`package.json`/source files with no checks, and accepted an unvalidated `--package-manager`.

**Symptoms fixed:**
- **Path traversal** — `tinkerise cli ../foo` / `tinkerise cli /tmp/x` wrote project files outside
  the current directory (the codebase explicitly guards this exact threat, T-33-10, in `preset`).
- **Invalid npm names** — `tinkerise cli "Bad Name"` / `@scope/x` produced an invalid `name` field,
  failing later with a confusing upstream `npm install` error.
- **Unknown package manager** — `--package-manager bogus` ran `execa('bogus', …)` → ENOENT →
  rendered as "Unexpected runtime failure — open an issue" for a user typo.

## Fix

Add a shared `assertValidTemplateInput(name, pm)` guard (validates against `ProjectNameSchema`
`^[a-z0-9][a-z0-9._-]{0,63}$` and the `npm|pnpm|yarn|bun` set) and call it at the start of all three
generators, before any filesystem work — throwing a structured `ConfigValidationError`. Mirrors the
scaffold (`executeScaffolder`) and preset patterns. Path validation also blocks the traversal vector.

## Test plan

- New `assertValidTemplateInput` unit tests (valid input; path-traversal/invalid names; bad PM).
- A wiring test per generator asserting it rejects an invalid name / unknown PM **before** any
  `mkdir`/`writeFile`.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ (core 60 files) · build ✅.

Note: this scopes to name/PM validation (the security + clear-UX wins). Refusing to overwrite an
existing same-named directory is a separate overwrite-protection concern, flagged for follow-up.