### PR TITLE
fix(core): refuse to overwrite a non-empty directory in cli/lib/mcp generators

### DIFF
--- a/.changeset/template-overwrite-protection.md
+++ b/.changeset/template-overwrite-protection.md
@@ -1,0 +1,7 @@
+---
+"@tinkerise/core": patch
+---
+
+The `cli`, `lib`, and `mcp` template generators now refuse to generate into a directory that already
+exists and is non-empty (throwing `TargetDirectoryExistsError`), instead of silently overwriting an
+existing project's files. A missing or empty target directory is still fine.

--- a/packages/core/src/errors/base.ts
+++ b/packages/core/src/errors/base.ts
@@ -306,3 +306,18 @@ export class InvalidJsonConfigError extends TinkeriseError {
     this.name = 'InvalidJsonConfigError'
   }
 }
+
+/**
+ * Thrown when a generator's target directory already exists and is not empty,
+ * so generation would overwrite existing files.
+ */
+export class TargetDirectoryExistsError extends TinkeriseError {
+  constructor(dir: string) {
+    super({
+      message: `Directory '${dir}' already exists and is not empty.`,
+      code: 'TARGET_DIRECTORY_EXISTS',
+      suggestion: 'Choose a different name or remove the existing directory first.',
+    })
+    this.name = 'TargetDirectoryExistsError'
+  }
+}

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -18,6 +18,7 @@ export {
   PresetNotFoundError,
   ScaffolderExitError,
   ScaffolderNotFoundError,
+  TargetDirectoryExistsError,
   TinkeriseError,
   UnknownEnhancementError,
   UnknownShellError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,7 @@ export {
   JsonUnsupportedCommandError,
   MissingPackageJsonError,
   PresetNotFoundError,
+  TargetDirectoryExistsError,
   TinkeriseError,
   UnknownEnhancementError,
   UnknownShellError,

--- a/packages/core/src/templates/cli-tool.ts
+++ b/packages/core/src/templates/cli-tool.ts
@@ -7,7 +7,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertTargetDirAvailable, assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a complete CLI tool project.
@@ -19,6 +19,7 @@ export async function generateCliTool(name: string, options: TemplateOptions = {
   const pm = options.packageManager ?? 'npm'
   assertValidTemplateInput(name, pm)
   const projectDir = name
+  await assertTargetDirAvailable(projectDir)
 
   // 1. Create project directory
   await mkdir(projectDir, { recursive: true })

--- a/packages/core/src/templates/lib.ts
+++ b/packages/core/src/templates/lib.ts
@@ -7,7 +7,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertTargetDirAvailable, assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a publish-ready npm library project.
@@ -19,6 +19,7 @@ export async function generateLib(name: string, options: TemplateOptions = {}): 
   const pm = options.packageManager ?? 'npm'
   assertValidTemplateInput(name, pm)
   const projectDir = name
+  await assertTargetDirAvailable(projectDir)
 
   // 1. Create project directory
   await mkdir(projectDir, { recursive: true })

--- a/packages/core/src/templates/mcp.ts
+++ b/packages/core/src/templates/mcp.ts
@@ -9,7 +9,7 @@
 
 import type { TemplateOptions } from './types.js'
 import { mkdir } from 'node:fs/promises'
-import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
+import { assertTargetDirAvailable, assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from './shared.js'
 
 /**
  * Generate a complete MCP server project.
@@ -21,6 +21,7 @@ export async function generateMcpServer(name: string, options: TemplateOptions =
   const pm = options.packageManager ?? 'npm'
   assertValidTemplateInput(name, pm)
   const projectDir = name
+  await assertTargetDirAvailable(projectDir)
 
   // 1. Create project directory
   await mkdir(projectDir, { recursive: true })

--- a/packages/core/src/templates/shared.ts
+++ b/packages/core/src/templates/shared.ts
@@ -6,12 +6,12 @@
  * printTemplateSummary — display a styled summary card after generation.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { ProjectNameSchema } from '@tinkerise/shared'
 import { execa } from 'execa'
 import pc from 'picocolors'
-import { ConfigValidationError } from '../errors/base.js'
+import { ConfigValidationError, TargetDirectoryExistsError } from '../errors/base.js'
 
 /** Package managers a template install can run (mirrors the PackageManager union). */
 const VALID_PACKAGE_MANAGERS = ['npm', 'pnpm', 'yarn', 'bun']
@@ -27,6 +27,26 @@ export function assertValidTemplateInput(name: string, packageManager: string): 
   }
   if (!VALID_PACKAGE_MANAGERS.includes(packageManager)) {
     throw new ConfigValidationError('packageManager', packageManager, VALID_PACKAGE_MANAGERS.join(', '))
+  }
+}
+
+/**
+ * Refuse to generate into a directory that already exists and is non-empty, so
+ * a generator never silently overwrites an existing project. A missing directory
+ * (ENOENT) or an existing empty one is fine.
+ */
+export async function assertTargetDirAvailable(projectDir: string): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await readdir(projectDir)
+  }
+  catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT')
+      return
+    throw err
+  }
+  if (entries.length > 0) {
+    throw new TargetDirectoryExistsError(projectDir)
   }
 }
 

--- a/packages/core/tests/templates/cli-tool.test.ts
+++ b/packages/core/tests/templates/cli-tool.test.ts
@@ -12,17 +12,20 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigValidationError } from '../../src/errors/base.js'
+import { ConfigValidationError, TargetDirectoryExistsError } from '../../src/errors/base.js'
 import { generateCliTool } from '../../src/templates/cli-tool.js'
 
 // Hoist mocks for vi.mock factories
 const mockMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+// Default: target directory does not exist (ENOENT) so generation proceeds.
+const mockReaddir = vi.hoisted(() => vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })))
 const mockExeca = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }))
 
 vi.mock('node:fs/promises', () => ({
   mkdir: mockMkdir,
   writeFile: mockWriteFile,
+  readdir: mockReaddir,
 }))
 
 vi.mock('execa', () => ({
@@ -54,6 +57,12 @@ describe('generateCliTool', () => {
   it('rejects an unknown package manager', async () => {
     await expect(generateCliTool('my-tool', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
     expect(mockMkdir).not.toHaveBeenCalled()
+  })
+
+  it('refuses to overwrite a non-empty existing directory', async () => {
+    mockReaddir.mockResolvedValueOnce(['package.json'])
+    await expect(generateCliTool('my-tool')).rejects.toBeInstanceOf(TargetDirectoryExistsError)
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { path, content } pairs */

--- a/packages/core/tests/templates/lib.test.ts
+++ b/packages/core/tests/templates/lib.test.ts
@@ -14,17 +14,20 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigValidationError } from '../../src/errors/base.js'
+import { ConfigValidationError, TargetDirectoryExistsError } from '../../src/errors/base.js'
 import { generateLib } from '../../src/templates/lib.js'
 
 // Hoist mocks for vi.mock factories
 const mockMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+// Default: target directory does not exist (ENOENT) so generation proceeds.
+const mockReaddir = vi.hoisted(() => vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })))
 const mockExeca = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }))
 
 vi.mock('node:fs/promises', () => ({
   mkdir: mockMkdir,
   writeFile: mockWriteFile,
+  readdir: mockReaddir,
 }))
 
 vi.mock('execa', () => ({
@@ -56,6 +59,12 @@ describe('generateLib', () => {
   it('rejects an unknown package manager', async () => {
     await expect(generateLib('my-lib', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
     expect(mockMkdir).not.toHaveBeenCalled()
+  })
+
+  it('refuses to overwrite a non-empty existing directory', async () => {
+    mockReaddir.mockResolvedValueOnce(['package.json'])
+    await expect(generateLib('my-lib')).rejects.toBeInstanceOf(TargetDirectoryExistsError)
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { path, content } pairs */

--- a/packages/core/tests/templates/mcp.test.ts
+++ b/packages/core/tests/templates/mcp.test.ts
@@ -14,17 +14,20 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigValidationError } from '../../src/errors/base.js'
+import { ConfigValidationError, TargetDirectoryExistsError } from '../../src/errors/base.js'
 import { generateMcpServer } from '../../src/templates/mcp.js'
 
 // Hoist mocks for vi.mock factories
 const mockMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+// Default: target directory does not exist (ENOENT) so generation proceeds.
+const mockReaddir = vi.hoisted(() => vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })))
 const mockExeca = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }))
 
 vi.mock('node:fs/promises', () => ({
   mkdir: mockMkdir,
   writeFile: mockWriteFile,
+  readdir: mockReaddir,
 }))
 
 vi.mock('execa', () => ({
@@ -56,6 +59,12 @@ describe('generateMcpServer', () => {
   it('rejects an unknown package manager', async () => {
     await expect(generateMcpServer('my-server', { packageManager: 'bogus' })).rejects.toThrow(ConfigValidationError)
     expect(mockMkdir).not.toHaveBeenCalled()
+  })
+
+  it('refuses to overwrite a non-empty existing directory', async () => {
+    mockReaddir.mockResolvedValueOnce(['package.json'])
+    await expect(generateMcpServer('my-server')).rejects.toBeInstanceOf(TargetDirectoryExistsError)
+    expect(mockWriteFile).not.toHaveBeenCalled()
   })
 
   /** Helper: get all writeFile calls as { filename, content } pairs */

--- a/packages/core/tests/templates/shared.test.ts
+++ b/packages/core/tests/templates/shared.test.ts
@@ -13,20 +13,24 @@
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ConfigValidationError } from '../../src/errors/base.js'
-import { assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from '../../src/templates/shared.js'
+import { ConfigValidationError, TargetDirectoryExistsError } from '../../src/errors/base.js'
+import { assertTargetDirAvailable, assertValidTemplateInput, printTemplateSummary, runInstall, writeProjectFile } from '../../src/templates/shared.js'
 
 const PROJECT_ROOT = join('/', 'tmp', 'project')
 const projectPath = (relativePath: string) => join(PROJECT_ROOT, ...relativePath.split('/'))
 
+const enoent = (): NodeJS.ErrnoException => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+
 // Hoist mocks for vi.mock factories
 const mockMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const mockReaddir = vi.hoisted(() => vi.fn())
 const mockExeca = vi.hoisted(() => vi.fn().mockResolvedValue({ stdout: '', stderr: '' }))
 
 vi.mock('node:fs/promises', () => ({
   mkdir: mockMkdir,
   writeFile: mockWriteFile,
+  readdir: mockReaddir,
 }))
 
 vi.mock('execa', () => ({
@@ -182,6 +186,30 @@ describe('shared template utilities', () => {
       catch (err) {
         expect((err as ConfigValidationError).code).toBe('CONFIG_VALIDATION')
       }
+    })
+  })
+
+  describe('assertTargetDirAvailable', () => {
+    it('resolves when the directory does not exist (ENOENT)', async () => {
+      mockReaddir.mockRejectedValueOnce(enoent())
+      await expect(assertTargetDirAvailable('new-app')).resolves.toBeUndefined()
+    })
+
+    it('resolves when the directory exists but is empty', async () => {
+      mockReaddir.mockResolvedValueOnce([])
+      await expect(assertTargetDirAvailable('empty-app')).resolves.toBeUndefined()
+    })
+
+    it('throws TargetDirectoryExistsError when the directory is non-empty', async () => {
+      mockReaddir.mockResolvedValueOnce(['package.json'])
+      const promise = assertTargetDirAvailable('existing-app')
+      await expect(promise).rejects.toBeInstanceOf(TargetDirectoryExistsError)
+      await expect(promise).rejects.toMatchObject({ code: 'TARGET_DIRECTORY_EXISTS' })
+    })
+
+    it('rethrows unexpected filesystem errors', async () => {
+      mockReaddir.mockRejectedValueOnce(Object.assign(new Error('EACCES'), { code: 'EACCES' }))
+      await expect(assertTargetDirAvailable('locked-app')).rejects.toThrow('EACCES')
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #64 (flagged there). The `cli`, `lib`, and `mcp` template generators used
`mkdir(name, { recursive: true })` and then wrote files unconditionally — so
`tinkerise cli existing-app` (a valid name that happens to collide with an existing project)
**silently overwrote** that project's `package.json`, `src/index.ts`, `README.md`, etc. (data loss).
The scaffold path is protected because upstream tools guard their own output; the tinkerise-owned
template generators were not.

## Fix

Add `assertTargetDirAvailable(projectDir)` (and a `TargetDirectoryExistsError`) that throws when the
target directory exists and is **non-empty**, run before any generation. A missing directory
(`ENOENT`) or an existing **empty** one is still fine, so the common case is unaffected; unexpected
filesystem errors (e.g. `EACCES`) propagate unchanged.

## Test plan

- `assertTargetDirAvailable` unit tests: ENOENT → ok, empty dir → ok, non-empty →
  `TargetDirectoryExistsError`, other fs error → rethrown.
- Per-generator wiring test: a non-empty target dir is refused before any `writeFile`.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ · build ✅. CLI command tests unaffected
  (they mock the generators).