### PR TITLE
fix(cli): preserve preset flags not offered as interactive options

### DIFF
--- a/.changeset/preset-flags-interactive-flow.md
+++ b/.changeset/preset-flags-interactive-flow.md
@@ -1,0 +1,9 @@
+---
+"@tinkerise/cli": patch
+---
+
+Fix preset/CLI scaffold flags being silently dropped in the interactive and category flows. Flags
+not offered as interactive checkboxes (e.g. `app-router`, `src-dir` for Next.js) were discarded by
+the options multiselect, so `tinkerise --preset <name>` could scaffold a project missing flags the
+preset requested. `selectFrameworkOptions` now preserves preselected flags that aren't on the
+checklist (and returns them for frameworks with no interactive options).

--- a/packages/cli/src/prompts/options-select.ts
+++ b/packages/cli/src/prompts/options-select.ts
@@ -40,20 +40,27 @@ export async function selectFrameworkOptions(
   framework: string,
   preselected?: string[],
 ): Promise<string[]> {
+  const pre = preselected ?? []
   const available = FRAMEWORK_OPTIONS[framework]
+  // No interactive options for this framework — keep any preselected flags
+  // (e.g. from a preset or CLI) rather than dropping them.
   if (!available || available.length === 0)
-    return []
+    return [...new Set(pre)]
 
   const result = await p.multiselect({
     message: 'Select options:',
     options: available,
     required: false,
-    initialValues: preselected ?? [],
+    initialValues: pre,
   })
 
   if (p.isCancel(result)) {
     process.exit(0)
   }
 
-  return result as string[]
+  // multiselect only returns values present in `available`, so re-add any
+  // preselected flags not offered as checkboxes (e.g. app-router for next).
+  const selected = result as string[]
+  const offList = pre.filter(v => !available.some(o => o.value === v))
+  return [...new Set([...selected, ...offList])]
 }

--- a/packages/cli/tests/prompts/options-select.test.ts
+++ b/packages/cli/tests/prompts/options-select.test.ts
@@ -101,6 +101,23 @@ describe('selectFrameworkOptions', () => {
     expect(result).toEqual(['typescript', 'eslint'])
   })
 
+  it('preserves preselected flags that are not offered as interactive options', async () => {
+    // clack multiselect only returns values present in its options, dropping 'app-router'
+    mockMultiselect.mockResolvedValue(['typescript'])
+
+    const result = await selectFrameworkOptions('next', ['app-router', 'typescript'])
+
+    expect(result).toContain('typescript')
+    expect(result).toContain('app-router')
+  })
+
+  it('returns preselected flags for a framework with no interactive options', async () => {
+    const result = await selectFrameworkOptions('django', ['typescript'])
+
+    expect(result).toEqual(['typescript'])
+    expect(mockMultiselect).not.toHaveBeenCalled()
+  })
+
   it('fRAMEWORK_OPTIONS has entries for next with TypeScript, Tailwind, ESLint, Biome', () => {
     const nextOptions = FRAMEWORK_OPTIONS.next
     expect(nextOptions).toBeDefined()

--- a/packages/cli/tests/prompts/options-select.test.ts
+++ b/packages/cli/tests/prompts/options-select.test.ts
@@ -118,6 +118,16 @@ describe('selectFrameworkOptions', () => {
     expect(mockMultiselect).not.toHaveBeenCalled()
   })
 
+  it('still lets the user deselect a preselected on-list flag (only off-list flags are forced to stay)', async () => {
+    // preselected typescript (on the checklist) + app-router (off it); user unchecks everything visible
+    mockMultiselect.mockResolvedValue([])
+
+    const result = await selectFrameworkOptions('next', ['typescript', 'app-router'])
+
+    expect(result).not.toContain('typescript')
+    expect(result).toContain('app-router')
+  })
+
   it('fRAMEWORK_OPTIONS has entries for next with TypeScript, Tailwind, ESLint, Biome', () => {
     const nextOptions = FRAMEWORK_OPTIONS.next
     expect(nextOptions).toBeDefined()


### PR DESCRIPTION
## Summary

Quality/hardening pass finding (second audit, behavioral dimension): in the **interactive** and
**category** flows, scaffold flags from a preset (or CLI) that aren't on the framework's interactive
checklist were **silently dropped**, producing a project missing flags the preset asked for.

**Concrete repro:** a preset `{ scaffold: { framework: 'next', flags: { 'app-router': true, typescript: true } } }`
run as `tinkerise --preset my-stack` (interactive). `FRAMEWORK_OPTIONS.next` only lists
`typescript/tailwind/eslint/biome`, so clack's `multiselect` — which only returns values present in
its options — discards `app-router`. `buildUserFlags` then only re-adds it from an explicit
`--app-router` CLI flag, so the Next.js app is scaffolded **without App Router, no warning**.
(`runDirectExecution`, i.e. `tinkerise web next app --preset x`, was unaffected — it skips the
multiselect.)

## Fix

`selectFrameworkOptions` now re-adds preselected flags that aren't offered as checkboxes (and
returns preselected flags as-is for frameworks with no interactive options). These map through
`mergePromptAndFlags` → `buildUserFlags` → `resolveFlags` exactly as a CLI flag would.

## Test plan

- New tests: preselected `app-router` survives a multiselect that returns only `typescript`;
  preselected flags returned for an option-less framework (no multiselect call).
- Full gate green: lint ✅ · typecheck ✅ · test ✅ (options-select 12, flow 13, no regressions) · build ✅.