### PR TITLE
fix(cli): show per-enhancement summary card for external npm enhancements

### DIFF
--- a/.changeset/external-enhancement-summary-card.md
+++ b/.changeset/external-enhancement-summary-card.md
@@ -1,0 +1,9 @@
+---
+"@tinkerise/cli": patch
+---
+
+`tinkerise add` now shows the per-enhancement summary card (files modified, packages added) for
+external npm enhancements too. The card was looked up from the built-in registry, which doesn't
+contain external modules, so they were silently omitted — exactly the "what did this third-party
+code touch" feedback that matters most for untrusted sources. It now resolves from the executed
+module list.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -215,9 +215,11 @@ export async function runAddCommand(
     },
   })
 
-  // 4. Show per-enhancement summary cards
+  // 4. Show per-enhancement summary cards. Look up from the executed module list
+  // (not the registry) so external npm enhancements get a card too.
+  const moduleById = new Map(modules.map(m => [m.id, m]))
   for (const installedId of summary.installed) {
-    const mod = enhancementRegistry.get(installedId)
+    const mod = moduleById.get(installedId)
     if (!mod)
       continue
     const result = summary.results.get(installedId) ?? {

--- a/packages/cli/tests/commands/add.test.ts
+++ b/packages/cli/tests/commands/add.test.ts
@@ -298,6 +298,26 @@ describe('runAddCommand', () => {
     )
   })
 
+  it('shows a per-enhancement summary card for an external npm enhancement', async () => {
+    const extResult = { success: true, filesModified: ['biome.json'], packagesAdded: ['@biomejs/biome'], warnings: [] }
+    const extMod = { id: 'biome', name: 'Biome', description: 'd', dependsOn: [], detect: vi.fn(), install: vi.fn() }
+    mockEnsureSourceTrusted.mockResolvedValue(true)
+    mockLoadNpmEnhancement.mockResolvedValue(extMod)
+    mockRunEnhancements.mockResolvedValue({
+      installed: ['biome'],
+      skipped: [],
+      failed: [],
+      notRun: [],
+      results: new Map([['biome', extResult]]),
+    })
+
+    await runAddCommand(['npm:tinkerise-enhancement-biome'], {})
+
+    expect(mockShowPerEnhancementSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ moduleId: 'biome', moduleName: 'Biome', result: extResult }),
+    )
+  })
+
   it('errors for an untrusted external source in CI (require pre-trust)', async () => {
     mockIsCI.value = true
     mockIsSourceTrusted.mockResolvedValue(false)


### PR DESCRIPTION
## Summary

Final concrete finding from the second hardening audit (MEDIUM-LOW, transparency). `tinkerise add`
prints a per-enhancement summary card (files modified, packages added, next steps) for each installed
module — but the loop resolved the module from `enhancementRegistry`, which doesn't contain external
(npm) modules. So `tinkerise add npm:tinkerise-enhancement-x` ran the module but **silently omitted
its card**, hiding exactly the "what did this third-party code touch" feedback that matters most for
untrusted sources. (Results still appeared in the overall summary, so output wasn't wrong — just
under-reported.)

## Fix

Resolve the card from the executed `modules` list (built-in + external) instead of the registry.

## Test plan

- New test: an external npm enhancement produces a `showPerEnhancementSummary` call with its
  `moduleId`/`moduleName`/`result`.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ (add 17) · build ✅.