### PR TITLE
fix(docs): correct & announce stack-builder copy feedback (a11y)

### DIFF
--- a/apps/docs/src/components/stack-builder.astro
+++ b/apps/docs/src/components/stack-builder.astro
@@ -108,6 +108,8 @@ const vocab = { frameworks, enhancements, namePattern, version: VERSION }
       Vite and T3 also need an interactive variant, so scaffold those directly.
     </p>
   </div>
+
+  <p id="sb-status" class="sb-sr-only" role="status" aria-live="polite"></p>
 </div>
 
 <script>
@@ -133,23 +135,37 @@ const vocab = { frameworks, enhancements, namePattern, version: VERSION }
     const pmSelect = root.querySelector<HTMLSelectElement>('#sb-pm')!
     const output = root.querySelector<HTMLElement>('#sb-output')!
     const lockOutput = root.querySelector<HTMLElement>('#sb-lock-output')!
+    const status = root.querySelector<HTMLElement>('#sb-status')!
 
     function selectedFramework(): FrameworkVocab | undefined {
       return vocab.frameworks.find(f => f.name === frameworkSelect.value)
     }
 
-    /** Copy getText()'s value on click, with transient button feedback. */
+    /**
+     * Copy getText()'s value on click, with transient button feedback mirrored
+     * to an aria-live region. Reports "Nothing to copy" instead of a false
+     * "Copied!" when there is no command/lock yet (e.g. invalid project name).
+     */
     function wireCopy(id: string, getText: () => string) {
       const button = root!.querySelector<HTMLButtonElement>(id)!
       const label = button.textContent
       button.addEventListener('click', async () => {
-        try {
-          await navigator.clipboard.writeText(getText())
-          button.textContent = 'Copied!'
+        const text = getText()
+        let message: string
+        if (!text) {
+          message = 'Nothing to copy'
         }
-        catch {
-          button.textContent = 'Copy failed'
+        else {
+          try {
+            await navigator.clipboard.writeText(text)
+            message = 'Copied!'
+          }
+          catch {
+            message = 'Copy failed'
+          }
         }
+        button.textContent = message
+        status.textContent = message
         setTimeout(() => { button.textContent = label }, 1500)
       })
     }
@@ -221,6 +237,17 @@ const vocab = { frameworks, enhancements, namePattern, version: VERSION }
     flex-direction: column;
     gap: 1.25rem;
     margin: 1.5rem 0;
+  }
+  .sb-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
   .sb-field {
     display: flex;


### PR DESCRIPTION
## Summary

Third hardening-sweep findings (#1 + #2), both in the Stack Builder copy buttons:

- **False "Copied!" on empty output** — when the command is cleared (e.g. an invalid project name),
  clicking Copy wrote an empty string to the clipboard but still flipped the button to "Copied!",
  telling the user they copied a command they didn't. Now reports **"Nothing to copy"** instead.
- **No screen-reader announcement** — copy feedback only mutated the button's own text, which assistive
  tech doesn't re-announce after the user's own click. Feedback is now mirrored to a visually-hidden
  `role="status" aria-live="polite"` region, so success/failure is announced.

## Test plan

Playwright against the built site:
- invalid name → button + status say "Nothing to copy" (no false success);
- valid name → "Copied!" announced + correct command on the clipboard;
- status region is visually hidden (~1px, sr-only); no console errors.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ · build ✅. Docs-only — no changeset.