### PR TITLE
fix(core): tolerate restore-write failures in the enhancement executor

### DIFF
--- a/.changeset/executor-restore-guard.md
+++ b/.changeset/executor-restore-guard.md
@@ -1,0 +1,8 @@
+---
+"@tinkerise/core": patch
+---
+
+Harden the enhancement executor: restoring a module's original files after an install error or a
+"skip" decision no longer aborts the whole run if a restore write fails. A failed restore is now
+logged as a warning and the remaining modules still run, honoring the executor's continue-on-failure
+contract.

--- a/packages/core/src/enhancements/executor.ts
+++ b/packages/core/src/enhancements/executor.ts
@@ -67,6 +67,21 @@ function _markRemainingAsNotRun(
 }
 
 /**
+ * Restore previously-saved file contents, tolerating per-file write failures so
+ * a failed restore never aborts the rest of the run (continue-on-failure contract).
+ */
+async function restoreFiles(files: Iterable<readonly [string, string]>): Promise<void> {
+  for (const [filePath, content] of files) {
+    try {
+      await writeFile(filePath, content, 'utf-8')
+    }
+    catch (err) {
+      tinkeriseLog(`Warning: could not restore ${filePath}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+}
+
+/**
  * Run the enhancement pipeline: sort -> detect -> resolve conflicts -> install.
  *
  * Modules are executed in topological (dependency-first) order.
@@ -158,9 +173,7 @@ export async function runEnhancements(
           error: err instanceof Error ? err.message : String(err),
         })
         // Restore original files
-        for (const [fp, content] of existingContents) {
-          await writeFile(fp, content, 'utf-8')
-        }
+        await restoreFiles(existingContents)
         tinkeriseLog(`Failed: ${mod.name} \u2718`)
         continue
       }
@@ -188,7 +201,7 @@ export async function runEnhancements(
 
         if (action === 'skip') {
           // Restore original content for this file
-          await writeFile(filePath, existingContent, 'utf-8')
+          await restoreFiles([[filePath, existingContent]])
           skipModule = true
           break
         }
@@ -197,9 +210,7 @@ export async function runEnhancements(
 
       if (skipModule) {
         // Restore ALL original files for this module
-        for (const [fp, content] of existingContents) {
-          await writeFile(fp, content, 'utf-8')
-        }
+        await restoreFiles(existingContents)
         summary.skipped.push(mod.id)
         tinkeriseLog(`Skipped ${mod.name}`)
         continue

--- a/packages/core/tests/enhancements/executor.test.ts
+++ b/packages/core/tests/enhancements/executor.test.ts
@@ -142,6 +142,29 @@ describe('runEnhancements()', () => {
     expect(mockWriteFile).toHaveBeenCalled()
   })
 
+  it('continues to the next module when restoring files fails after an install error', async () => {
+    // A restore write that throws must not abort the whole run.
+    mockWriteFile.mockReset().mockRejectedValue(new Error('EACCES: read-only'))
+
+    const failing = mockModule({
+      id: 'eslint',
+      detect: async () => ({
+        installed: true,
+        configFiles: [projectPath('.eslintrc.json')],
+        partial: false,
+      }),
+      install: async () => {
+        throw new Error('install boom')
+      },
+    })
+    const after = mockModule({ id: 'prettier' })
+
+    const result = await runEnhancements(makeOpts([failing, after]))
+
+    expect(result.failed.map(f => f.id)).toContain('eslint')
+    expect(result.installed).toContain('prettier')
+  })
+
   it('installs module when conflict detected and user chooses replace', async () => {
     // First read: existing content. Second read: new content after install.
     mockReadFile


### PR DESCRIPTION
## Summary

Third hardening-sweep finding (#3, robustness). When a module's `install` throws, or the user picks
"skip" on a conflict, the executor restores the previously-saved file contents. Those restore writes
were **unguarded** — if a restore `writeFile` failed (e.g. a file became read-only mid-run), the
error propagated out of `runEnhancements`, **aborting all remaining modules** and replacing the
end-of-run summary with an uncaught error. That violates the executor's documented continue-on-failure
contract (every other failure is funneled into `summary.failed` and the loop continues).

## Fix

A `restoreFiles` helper wraps each restore write in try/catch, logging a warning per failed restore
and continuing. Applied to all three restore sites (install-error, per-file skip, skip-all).

## Test plan

- New test: a module whose install throws **and** whose restore write rejects → `runEnhancements`
  still resolves, records that module as failed, and the next module still installs.
- Full gate green: lint ✅ · typecheck ✅ · test ✅ (executor 11) · build ✅.